### PR TITLE
BluePill F103C8 support

### DIFF
--- a/boards/bluepill_f103c8.json
+++ b/boards/bluepill_f103c8.json
@@ -17,5 +17,5 @@
     "protocol": "stlink"
   }, 
   "url": "http://www.st.com/content/st_com/en/products/microcontrollers/stm32-32-bit-arm-cortex-mcus/stm32f1-series/stm32f103/stm32f103c8.html", 
-  "vendor": "generic"
+  "vendor": "Generic"
 }

--- a/boards/bluepill_f103c8.json
+++ b/boards/bluepill_f103c8.json
@@ -1,0 +1,21 @@
+{
+  "build": {
+    "core": "stm32", 
+    "cpu": "cortex-m3", 
+    "f_cpu": "72000000L", 
+    "ldscript": "stm32f103xb.ld", 
+    "mcu": "stm32f103c8t6", 
+    "variant": "stm32f1"
+  }, 
+  "frameworks": [
+    "mbed"
+  ], 
+  "name": "BluePill F103C8", 
+  "upload": {
+    "maximum_ram_size": 20480, 
+    "maximum_size": 65536,
+    "protocol": "stlink"
+  }, 
+  "url": "http://www.st.com/content/st_com/en/products/microcontrollers/stm32-32-bit-arm-cortex-mcus/stm32f1-series/stm32f103/stm32f103c8.html", 
+  "vendor": "generic"
+}


### PR DESCRIPTION
Board definition for BLUEPILL_F103C8 mbed-lib target.