### PR TITLE
Added missing BluePill F103C8 board hardware id's

### DIFF
--- a/boards/bluepill_f103c8.json
+++ b/boards/bluepill_f103c8.json
@@ -4,6 +4,10 @@
     "cpu": "cortex-m3",
     "extra_flags": "-DSTM32F103xB",
     "f_cpu": "72000000L",
+    "hwids": [
+        ["0x1EAF", "0x0003"],
+        ["0x1EAF", "0x0004"]
+    ],
     "ldscript": "stm32f103xb.ld",
     "mcu": "stm32f103c8t6",
     "variant": "stm32f1"


### PR DESCRIPTION
When building project and using arduino framework with this board, configuration of generic_STM32F103C8 is used instead. However, stm32duino supports other flashing methods(dfu with stm32duino bootloader for example) which requires usb hwid's and seems like we forgot to add them.
The issue behid this is #53 