### PR TITLE
Fix the path to stm32 ld script in the mbed framework

### DIFF
--- a/builder/frameworks/cmsis.py
+++ b/builder/frameworks/cmsis.py
@@ -60,9 +60,9 @@ if not isfile(join(platform.get_dir(), "ldscripts", ldscript)):
             LINKFLAGS=[
                 '-Wl,-T"%s"' %
                 join(
-                    platform.get_package_dir("framework-mbed"), "variant",
-                    env.subst("$BOARD").upper(), "mbed",
-                    "TARGET_%s" % env.subst("$BOARD").upper(),
+                    platform.get_package_dir("framework-mbed"), "targets",
+                    "TARGET_STM", "TARGET_%s" % env.BoardConfig().get("build.variant")[:7],
+                    "TARGET_%s" % env.subst("$BOARD").upper(), "device",
                     "TOOLCHAIN_GCC_ARM", "%s.ld" % ldscript.upper()[:-3]
                 )
             ]

--- a/builder/frameworks/cmsis.py
+++ b/builder/frameworks/cmsis.py
@@ -61,7 +61,7 @@ if not isfile(join(platform.get_dir(), "ldscripts", ldscript)):
                 '-Wl,-T"%s"' %
                 join(
                     platform.get_package_dir("framework-mbed"), "targets",
-                    "TARGET_STM", "TARGET_%s" % env.BoardConfig().get("build.variant")[:7],
+                    "TARGET_STM", "TARGET_%s" % env.BoardConfig().get("build.variant").upper()[:7],
                     "TARGET_%s" % env.subst("$BOARD").upper(), "device",
                     "TOOLCHAIN_GCC_ARM", "%s.ld" % ldscript.upper()[:-3]
                 )

--- a/builder/frameworks/spl.py
+++ b/builder/frameworks/spl.py
@@ -66,9 +66,9 @@ if not isfile(join(platform.get_dir(), "ldscripts", ldscript)):
             LINKFLAGS=[
                 '-Wl,-T"%s"' %
                 join(
-                    platform.get_package_dir("framework-mbed"), "variant",
-                    env.subst("$BOARD").upper(), "mbed",
-                    "TARGET_%s" % env.subst("$BOARD").upper(),
+                    platform.get_package_dir("framework-mbed"), "targets",
+                    "TARGET_STM", "TARGET_%s" % env.BoardConfig().get("build.variant")[:7],
+                    "TARGET_%s" % env.subst("$BOARD").upper(), "device",
                     "TOOLCHAIN_GCC_ARM", "%s.ld" % ldscript.upper()[:-3]
                 )
             ]


### PR DESCRIPTION
The mbed framework changed the path to *.ld scripts, and now instead of
path (for example):
~/.platformio/packages/framework-mbed/variant/BLUEPILL_F103C8/mbed/TARGE
T_BLUEPILL_F103C8/TOOLCHAIN_GCC_ARM/STM32F103XB.ld
must be:
~/.platformio/packages/framework-mbed/targets/TARGET_STM/TARGET_stm32f1/
TARGET_BLUEPILL_F103C8/device/TOOLCHAIN_GCC_ARM/STM32F103XB.ld