### PR TITLE
Change stm32f103c generic boards bootloader version

### DIFF
--- a/builder/frameworks/arduino.py
+++ b/builder/frameworks/arduino.py
@@ -87,7 +87,8 @@ if env.subst("$UPLOAD_PROTOCOL") == "dfu":
 
         if "stm32f103r" in board.get("build.mcu", ""):
             env.Replace(LDSCRIPT_PATH="bootloader.ld")
-        elif board.get("upload.boot_version", 0) == 2:
+        elif ("stm32f103c" in board.get("build.mcu", "") or
+                board.get("upload.boot_version", 0) == 2):
             env.Replace(LDSCRIPT_PATH="bootloader_20.ld")
 else:
     env.Append(CPPDEFINES=[("VECT_TAB_ADDR", 0x8000000)])


### PR DESCRIPTION
Changed generic stm32f103c boards bootloader version to 2. 

All of these boards uses stm32bootloader, which is in fact version 2. (Version 1 is only used by Maple and Maple Mini Original)

Without this, wrong linker script is used and flashing doesn't work.

issues #53 #38 can be closed now.