### PR TITLE
Add STM32L073Z-EVAL board definition.

### DIFF
--- a/boards/eval_l073z.json
+++ b/boards/eval_l073z.json
@@ -1,0 +1,32 @@
+{
+  "build": {
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DSTM32L073xx",
+    "f_cpu": "32000000L",
+    "mcu": "stm32l073vzt6"
+  },
+  "frameworks": [
+    "mbed",
+    "stm32cube"
+  ],
+  "name": "ST STM32L073Z-EVAL",
+  "upload": {
+    "maximum_ram_size": 20480,
+    "maximum_size": 196608,
+    "protocol": "stlink"
+  },
+  "debug": {
+    "tools": {
+      "stlink-v2-1": {
+        "server": {
+          "package": "tool-openocd",
+          "executable": "bin/openocd",
+          "arguments": ["-f", "scripts/board/stm32l0discovery.cfg"]
+        },
+        "onboard": true
+      }
+    }
+  },
+  "url": "http://www.st.com/content/st_com/en/products/evaluation-tools/product-evaluation-tools/mcu-eval-tools/stm32-mcu-eval-tools/stm32-mcu-eval-boards/stm32l073z-eval.html",
+  "vendor": "ST"
+}


### PR DESCRIPTION
Board definition for [STM32L073Z-EVAL](http://www.st.com/content/st_com/en/products/evaluation-tools/product-evaluation-tools/mcu-eval-tools/stm32-mcu-eval-tools/stm32-mcu-eval-boards/stm32l073z-eval.html).