### PR TITLE
Refactor STM32F407VE board config

### DIFF
--- a/boards/genericSTM32F407VET6.json
+++ b/boards/genericSTM32F407VET6.json
@@ -2,15 +2,19 @@
   "build": {
     "core": "stm32",
     "cpu": "cortex-m4",
-    "extra_flags": "-mthumb -DSTM32F4 -DSTM32_HIGH_DENSITY",
+    "extra_flags": "-DSTM32F407xx",
     "f_cpu": "168000000L",
     "hwids": [
+      [
+        "0x1EAF",
+        "0x0003"
+      ],
       [
         "0x0483",
         "0x3748"
       ]
     ],
-    "ldscript": "jtag.ld",
+    "ldscript": "stm32f407xe.ld",
     "mcu": "stm32f407vet6",
     "variant": "stm32f4"
   },
@@ -37,16 +41,22 @@
     }
   },
   "frameworks": [
-    "arduino"
+    "arduino",
+    "stm32cube"
   ],
   "name": "STM32F407VE (192k RAM. 512k Flash)",
   "upload": {
+    "disable_flushing": false,
     "maximum_ram_size": 131072,
     "maximum_size": 514288,
     "protocol": "stlink",
     "protocols": [
-      "stlink"
-    ]
+      "stlink",
+      "dfu"
+    ],
+    "require_upload_port": true,
+    "use_1200bps_touch": false,
+    "wait_for_upload_port": false
   },
   "url": "http://www.st.com/en/microcontrollers/stm32f407ve.html",
   "vendor": "Generic"

--- a/builder/frameworks/arduino/maple/stm32f4.py
+++ b/builder/frameworks/arduino/maple/stm32f4.py
@@ -35,6 +35,7 @@ FRAMEWORK_DIR = join(platform.get_package_dir(
 assert isdir(FRAMEWORK_DIR)
 
 # default configuration values
+vector = int(board.get("build.vec_tab_addr", "0x8000000"), 16)
 error_led_port = "GPIOA"
 error_led_pin = 7
 
@@ -44,24 +45,22 @@ if "stm32f407ve" in mcu_type:
     ldscript = "jtag.ld"
     variant = "generic_f407v"
 
-
 # upload related configuration remap
-# for all generic boards
 upload_protocol = env.subst("$UPLOAD_PROTOCOL")
 
+if upload_protocol == "dfu":
+    vector = 0x8004000
+    if "f407v" in mcu_type:
+        ldscript = "bootloader_8004000.ld"
+
 env.Append(
-    CFLAGS=[
-        "-std=gnu11"
-    ],
+    CFLAGS=["-std=gnu11"],
+
+    CXXFLAGS=["-std=gnu++11"],
 
     CCFLAGS=[
         "-MMD",
-        "--param",
-        "max-inline-insns-single=500"
-    ],
-
-    CXXFLAGS=[
-        "-std=gnu++11"
+        "--param", "max-inline-insns-single=500",
     ],
 
     CPPDEFINES=[
@@ -73,10 +72,10 @@ env.Append(
         ("ARDUINO_%s" % variant.upper()),
         ("ARDUINO_ARCH_STM32F4"),
         ("VECT_TAB_FLASH"),
-        ("USER_ADDR_ROM=0x08000000"),
+        ("USER_ADDR_ROM", vector),
         ("__STM32F4__"),
-        ("MCU_%s" % mcu_type.upper()),
-        ("SERIAL_USB") # this is so that usb serial is connected when the board boots, use USB_MSC for having USB Mass Storage (MSC) instead
+        ("STM32_HIGH_DENSITY"),
+        ("USB_NC")
     ],
 
     CPPPATH=[
@@ -88,9 +87,7 @@ env.Append(
         join(FRAMEWORK_DIR, "system", "libmaple"),
     ],
 
-    LIBPATH=[join(FRAMEWORK_DIR, "variants", variant, "ld")],
-
-    LIBS=["c"]
+    LIBPATH=[join(FRAMEWORK_DIR, "variants", variant, "ld")]
 )
 
 # remap ldscript
@@ -102,9 +99,13 @@ for item in ("-nostartfiles", "-nostdlib"):
         env['LINKFLAGS'].remove(item)
 
 # remove unused libraries
-for item in ("stdc++", "nosys"):
+for item in ("c", "stdc++", "nosys"):
     if item in env['LIBS']:
         env['LIBS'].remove(item)
+
+# remove USB inactive serial flag if other flags are used
+if "SERIAL_USB" in env['CPPDEFINES'] or "USB_MSC" in env['CPPDEFINES']:
+    env['CPPDEFINES'].remove("USB_NC")
 
 #
 # Lookup for specific core's libraries

--- a/builder/frameworks/stm32cube.py
+++ b/builder/frameworks/stm32cube.py
@@ -44,7 +44,8 @@ STARTUP_FILE_EXCEPTIONS = {
     "stm32f103r8": "startup_stm32f103xb.s",
     "stm32f103rc": "startup_stm32f103xb.s",
     "stm32f103vc": "startup_stm32f103xe.s",
-    "stm32f103ve": "startup_stm32f103xe.s"
+    "stm32f103ve": "startup_stm32f103xe.s",
+    "stm32f407ve": "startup_stm32f407xx.s"
 }
 
 


### PR DESCRIPTION
- added stm32cube support
- added dfu upload protocol support

I haven't seen linker script for 407VE in `libopencm3` so I think `libopencm3` doesn't support it out-of-the-box.
`STM32Cube` and `DFU` flashing should be tested to verify if they do work. Perhaps @sczekajewski could help us?

Note: usb storage is set as `USB inactive`, since it's default in Arduino environment. In order to switch:

- For `USB Serial (CDC)` use `build_flags=-DSERIAL_USB`
- For `USB Mass Storage (MSC)` use `build_flags=-DUSB_MSC`

@ivankravets oh and one more thing...
Board's config file should be `genericSTM32F407VE.json`. However, I didn't changed it, because some users might be using this board config and newer update could break things for them. Should we leave it like this?