### PR TITLE
Feature/add stmf1 boards

### DIFF
--- a/boards/genericSTM32F103C8.json
+++ b/boards/genericSTM32F103C8.json
@@ -2,7 +2,7 @@
   "build": {
     "core": "stm32",
     "cpu": "cortex-m3",
-    "extra_flags": "-DSTM32F103x8",
+    "extra_flags": "-DSTM32F103xB",
     "f_cpu": "72000000L",
     "hwids": [
       [

--- a/boards/genericSTM32F103R8.json
+++ b/boards/genericSTM32F103R8.json
@@ -2,7 +2,7 @@
   "build": {
     "core": "stm32",
     "cpu": "cortex-m3",
-    "extra_flags": "-DSTM32F103x8",
+    "extra_flags": "-DSTM32F103xB",
     "f_cpu": "72000000L",
     "hwids": [
       [

--- a/boards/genericSTM32F103RC.json
+++ b/boards/genericSTM32F103RC.json
@@ -2,7 +2,7 @@
   "build": {
     "core": "stm32",
     "cpu": "cortex-m3",
-    "extra_flags": "-DSTM32F103xC",
+    "extra_flags": "-DSTM32F103xE",
     "f_cpu": "72000000L",
     "hwids": [
       [

--- a/boards/genericSTM32F103T8.json
+++ b/boards/genericSTM32F103T8.json
@@ -1,0 +1,49 @@
+{
+  "build": {
+    "core": "stm32",
+    "cpu": "cortex-m3",
+    "extra_flags": "-DSTM32F103x8",
+    "f_cpu": "72000000L",
+    "hwids": [
+      [
+        "0x1EAF",
+        "0x0003"
+      ],
+      [
+        "0x1EAF",
+        "0x0004"
+      ]
+    ],
+    "ldscript": "stm32f103x8.ld",
+    "mcu": "stm32f103t8t6",
+    "variant": "stm32f1"
+  },
+  "debug": {
+    "openocd_target": "stm32f1x",
+    "svd_path": "STM32F103xx.svd"
+  },
+  "frameworks": [
+    "arduino",
+    "libopencm3",
+    "stm32cube"
+  ],
+  "name": "STM32F103T8 (20k RAM. 64k Flash)",
+  "upload": {
+    "disable_flushing": false,
+    "maximum_ram_size": 65536,
+    "maximum_size": 20480,
+    "protocol": "stlink",
+    "protocols": [
+      "jlink",
+      "stlink",
+      "blackmagic",
+      "serial",
+      "dfu"
+    ],
+    "require_upload_port": true,
+    "use_1200bps_touch": false,
+    "wait_for_upload_port": false
+  },
+  "url": "http://www.st.com/en/microcontrollers/stm32f103t8.html",
+  "vendor": "Generic"
+}

--- a/boards/genericSTM32F103T8.json
+++ b/boards/genericSTM32F103T8.json
@@ -2,7 +2,7 @@
   "build": {
     "core": "stm32",
     "cpu": "cortex-m3",
-    "extra_flags": "-DSTM32F103x8",
+    "extra_flags": "-DSTM32F103xB",
     "f_cpu": "72000000L",
     "hwids": [
       [

--- a/boards/genericSTM32F103TB.json
+++ b/boards/genericSTM32F103TB.json
@@ -1,0 +1,49 @@
+{
+  "build": {
+    "core": "stm32",
+    "cpu": "cortex-m3",
+    "extra_flags": "-DSTM32F103xB",
+    "f_cpu": "72000000L",
+    "hwids": [
+      [
+        "0x1EAF",
+        "0x0003"
+      ],
+      [
+        "0x1EAF",
+        "0x0004"
+      ]
+    ],
+    "ldscript": "stm32f103xb.ld",
+    "mcu": "stm32f103tbt6",
+    "variant": "stm32f1"
+  },
+  "debug": {
+    "openocd_target": "stm32f1x",
+    "svd_path": "STM32F103xx.svd"
+  },
+  "frameworks": [
+    "arduino",
+    "libopencm3",
+    "stm32cube"
+  ],
+  "name": "STM32F103TB (20k RAM. 128k Flash)",
+  "upload": {
+    "disable_flushing": false,
+    "maximum_ram_size": 20480,
+    "maximum_size": 131072,
+    "protocol": "stlink",
+    "protocols": [
+      "jlink",
+      "stlink",
+      "blackmagic",
+      "serial",
+      "dfu"
+    ],
+    "require_upload_port": true,
+    "use_1200bps_touch": false,
+    "wait_for_upload_port": false
+  },
+  "url": "http://www.st.com/en/microcontrollers/stm32f103tb.html",
+  "vendor": "Generic"
+}

--- a/boards/genericSTM32F103VB.json
+++ b/boards/genericSTM32F103VB.json
@@ -1,0 +1,49 @@
+{
+  "build": {
+    "core": "stm32",
+    "cpu": "cortex-m3",
+    "extra_flags": "-DSTM32F103xB",
+    "f_cpu": "72000000L",
+    "hwids": [
+      [
+        "0x1EAF",
+        "0x0003"
+      ],
+      [
+        "0x1EAF",
+        "0x0004"
+      ]
+    ],
+    "ldscript": "stm32f103xb.ld",
+    "mcu": "stm32f103vbt6",
+    "variant": "stm32f1"
+  },
+  "debug": {
+    "openocd_target": "stm32f1x",
+    "svd_path": "STM32F103xx.svd"
+  },
+  "frameworks": [
+    "arduino",
+    "libopencm3",
+    "stm32cube"
+  ],
+  "name": "STM32F103VB (20k RAM. 128k Flash)",
+  "upload": {
+    "disable_flushing": false,
+    "maximum_ram_size": 20480,
+    "maximum_size": 131072,
+    "protocol": "stlink",
+    "protocols": [
+      "jlink",
+      "stlink",
+      "blackmagic",
+      "serial",
+      "dfu"
+    ],
+    "require_upload_port": true,
+    "use_1200bps_touch": false,
+    "wait_for_upload_port": false
+  },
+  "url": "http://www.st.com/en/microcontrollers/stm32f103vb.html",
+  "vendor": "Generic"
+}

--- a/boards/genericSTM32F103VC.json
+++ b/boards/genericSTM32F103VC.json
@@ -2,7 +2,7 @@
   "build": {
     "core": "stm32",
     "cpu": "cortex-m3",
-    "extra_flags": "-DSTM32F103xC",
+    "extra_flags": "-DSTM32F103xE",
     "f_cpu": "72000000L",
     "hwids": [
       [

--- a/boards/genericSTM32F103VD.json
+++ b/boards/genericSTM32F103VD.json
@@ -1,0 +1,49 @@
+{
+  "build": {
+    "core": "stm32",
+    "cpu": "cortex-m3",
+    "extra_flags": "-DSTM32F103xD",
+    "f_cpu": "72000000L",
+    "hwids": [
+      [
+        "0x1EAF",
+        "0x0003"
+      ],
+      [
+        "0x1EAF",
+        "0x0004"
+      ]
+    ],
+    "ldscript": "stm32f103xd.ld",
+    "mcu": "stm32f103vdt6",
+    "variant": "stm32f1"
+  },
+  "debug": {
+    "openocd_target": "stm32f1x",
+    "svd_path": "STM32F103xx.svd"
+  },
+  "frameworks": [
+    "arduino",
+    "libopencm3",
+    "stm32cube"
+  ],
+  "name": "STM32F103VD (64k RAM. 384k Flash)",
+  "upload": {
+    "disable_flushing": false,
+    "maximum_ram_size": 65536,
+    "maximum_size": 393216,
+    "protocol": "stlink",
+    "protocols": [
+      "jlink",
+      "stlink",
+      "blackmagic",
+      "serial",
+      "dfu"
+    ],
+    "require_upload_port": true,
+    "use_1200bps_touch": false,
+    "wait_for_upload_port": false
+  },
+  "url": "http://www.st.com/en/microcontrollers/stm32f103vd.html",
+  "vendor": "Generic"
+}

--- a/boards/genericSTM32F103VD.json
+++ b/boards/genericSTM32F103VD.json
@@ -2,7 +2,7 @@
   "build": {
     "core": "stm32",
     "cpu": "cortex-m3",
-    "extra_flags": "-DSTM32F103xD",
+    "extra_flags": "-DSTM32F103xE",
     "f_cpu": "72000000L",
     "hwids": [
       [

--- a/boards/genericSTM32F103ZC.json
+++ b/boards/genericSTM32F103ZC.json
@@ -1,0 +1,49 @@
+{
+  "build": {
+    "core": "stm32",
+    "cpu": "cortex-m3",
+    "extra_flags": "-DSTM32F103xC",
+    "f_cpu": "72000000L",
+    "hwids": [
+      [
+        "0x1EAF",
+        "0x0003"
+      ],
+      [
+        "0x1EAF",
+        "0x0004"
+      ]
+    ],
+    "ldscript": "stm32f103xc.ld",
+    "mcu": "stm32f103zct6",
+    "variant": "stm32f1"
+  },
+  "debug": {
+    "openocd_target": "stm32f1x",
+    "svd_path": "STM32F103xx.svd"
+  },
+  "frameworks": [
+    "arduino",
+    "libopencm3",
+    "stm32cube"
+  ],
+  "name": "STM32F103ZC (48k RAM. 256k Flash)",
+  "upload": {
+    "disable_flushing": false,
+    "maximum_ram_size": 49152,
+    "maximum_size": 262144,
+    "protocol": "stlink",
+    "protocols": [
+      "jlink",
+      "stlink",
+      "blackmagic",
+      "serial",
+      "dfu"
+    ],
+    "require_upload_port": true,
+    "use_1200bps_touch": false,
+    "wait_for_upload_port": false
+  },
+  "url": "http://www.st.com/en/microcontrollers/stm32f103zc.html",
+  "vendor": "Generic"
+}

--- a/boards/genericSTM32F103ZC.json
+++ b/boards/genericSTM32F103ZC.json
@@ -2,7 +2,7 @@
   "build": {
     "core": "stm32",
     "cpu": "cortex-m3",
-    "extra_flags": "-DSTM32F103xC",
+    "extra_flags": "-DSTM32F103xE",
     "f_cpu": "72000000L",
     "hwids": [
       [

--- a/boards/genericSTM32F103ZD.json
+++ b/boards/genericSTM32F103ZD.json
@@ -1,0 +1,49 @@
+{
+  "build": {
+    "core": "stm32",
+    "cpu": "cortex-m3",
+    "extra_flags": "-DSTM32F103xD",
+    "f_cpu": "72000000L",
+    "hwids": [
+      [
+        "0x1EAF",
+        "0x0003"
+      ],
+      [
+        "0x1EAF",
+        "0x0004"
+      ]
+    ],
+    "ldscript": "stm32f103xd.ld",
+    "mcu": "stm32f103zdt6",
+    "variant": "stm32f1"
+  },
+  "debug": {
+    "openocd_target": "stm32f1x",
+    "svd_path": "STM32F103xx.svd"
+  },
+  "frameworks": [
+    "arduino",
+    "libopencm3",
+    "stm32cube"
+  ],
+  "name": "STM32F103ZD (64k RAM. 384k Flash)",
+  "upload": {
+    "disable_flushing": false,
+    "maximum_ram_size": 65536,
+    "maximum_size": 393216,
+    "protocol": "stlink",
+    "protocols": [
+      "jlink",
+      "stlink",
+      "blackmagic",
+      "serial",
+      "dfu"
+    ],
+    "require_upload_port": true,
+    "use_1200bps_touch": false,
+    "wait_for_upload_port": false
+  },
+  "url": "http://www.st.com/en/microcontrollers/stm32f103zd.html",
+  "vendor": "Generic"
+}

--- a/boards/genericSTM32F103ZD.json
+++ b/boards/genericSTM32F103ZD.json
@@ -2,7 +2,7 @@
   "build": {
     "core": "stm32",
     "cpu": "cortex-m3",
-    "extra_flags": "-DSTM32F103xD",
+    "extra_flags": "-DSTM32F103xE",
     "f_cpu": "72000000L",
     "hwids": [
       [

--- a/boards/genericSTM32F103ZE.json
+++ b/boards/genericSTM32F103ZE.json
@@ -1,0 +1,49 @@
+{
+  "build": {
+    "core": "stm32",
+    "cpu": "cortex-m3",
+    "extra_flags": "-DSTM32F103xE",
+    "f_cpu": "72000000L",
+    "hwids": [
+      [
+        "0x1EAF",
+        "0x0003"
+      ],
+      [
+        "0x1EAF",
+        "0x0004"
+      ]
+    ],
+    "ldscript": "stm32f103xe.ld",
+    "mcu": "stm32f103zet6",
+    "variant": "stm32f1"
+  },
+  "debug": {
+    "openocd_target": "stm32f1x",
+    "svd_path": "STM32F103xx.svd"
+  },
+  "frameworks": [
+    "arduino",
+    "libopencm3",
+    "stm32cube"
+  ],
+  "name": "STM32F103ZE (64k RAM. 512k Flash)",
+  "upload": {
+    "disable_flushing": false,
+    "maximum_ram_size": 65536,
+    "maximum_size": 524288,
+    "protocol": "stlink",
+    "protocols": [
+      "jlink",
+      "stlink",
+      "blackmagic",
+      "serial",
+      "dfu"
+    ],
+    "require_upload_port": true,
+    "use_1200bps_touch": false,
+    "wait_for_upload_port": false
+  },
+  "url": "http://www.st.com/en/microcontrollers/stm32f103ze.html",
+  "vendor": "Generic"
+}

--- a/boards/maple_ret6.json
+++ b/boards/maple_ret6.json
@@ -1,0 +1,46 @@
+{
+  "build": {
+    "core": "stm32",
+    "cpu": "cortex-m3",
+    "extra_flags": "-DSTM32F103xE",
+    "f_cpu": "72000000L",
+    "hwids": [
+      [
+        "0x1EAF",
+        "0x0003"
+      ],
+      [
+        "0x1EAF",
+        "0x0004"
+      ]
+    ],
+    "ldscript": "stm32f103xe.ld",
+    "mcu": "stm32f103ret6",
+    "variant": "stm32f1"
+  },
+  "debug": {
+    "openocd_target": "stm32f1x",
+    "svd_path": "STM32F103xx.svd"
+  },
+  "frameworks": [
+    "arduino",
+    "libopencm3",
+    "stm32cube"
+  ],
+  "name": "Maple (RET6)",
+  "upload": {
+    "boot_version": 1,
+    "maximum_ram_size": 49152,
+    "maximum_size": 262144,
+    "protocol": "dfu",
+    "protocols": [
+      "jlink",
+      "stlink",
+      "blackmagic",
+      "dfu"
+    ],
+    "require_upload_port": true
+  },
+  "url": "http://www.leaflabs.com/maple/",
+  "vendor": "LeafLabs"
+}

--- a/boards/microduino32_flash.json
+++ b/boards/microduino32_flash.json
@@ -29,6 +29,7 @@
   ],
   "name": "Microduino Core STM32 to Flash",
   "upload": {
+    "boot_version": 1,
     "disable_flushing": false,
     "maximum_ram_size": 17000,
     "maximum_size": 108000,

--- a/boards/microduino32_flash.json
+++ b/boards/microduino32_flash.json
@@ -1,0 +1,48 @@
+{
+  "build": {
+    "core": "stm32",
+    "cpu": "cortex-m3",
+    "extra_flags": "-DSTM32F103xB",
+    "f_cpu": "72000000L",
+    "hwids": [
+      [
+        "0x1EAF",
+        "0x0003"
+      ],
+      [
+        "0x1EAF",
+        "0x0004"
+      ]
+    ],
+    "ldscript": "stm32f103xb.ld",
+    "mcu": "stm32f103cbt6",
+    "variant": "stm32f1"
+  },
+  "debug": {
+    "openocd_target": "stm32f1x",
+    "svd_path": "STM32F103xx.svd"
+  },
+  "frameworks": [
+    "arduino",
+    "libopencm3",
+    "stm32cube"
+  ],
+  "name": "Microduino Core STM32 to Flash",
+  "upload": {
+    "disable_flushing": false,
+    "maximum_ram_size": 17000,
+    "maximum_size": 108000,
+    "protocol": "dfu",
+    "protocols": [
+      "jlink",
+      "stlink",
+      "blackmagic",
+      "dfu"
+    ],
+    "require_upload_port": true,
+    "use_1200bps_touch": false,
+    "wait_for_upload_port": false
+  },
+  "url": "http://wiki.microduinoinc.com/Microduino-Module_CoreSTM32",
+  "vendor": "Microduino"
+}

--- a/builder/frameworks/arduino/maple/stm32f1.py
+++ b/builder/frameworks/arduino/maple/stm32f1.py
@@ -43,8 +43,10 @@ error_led_pin = 1
 mcu_type = board.get("build.mcu")[:-2]
 if "f103c8" in mcu_type:
     ldscript = "jtag_c8.ld"
-elif "f103cb" in mcu_type:
+elif "f103cb" in mcu_type or "f103tb" in mcu_type:
     ldscript = "jtag.ld"
+elif "f103t8" in mcu_type:
+    ldscript = "jtag_t8.ld"
 else:
     ldscript = "%s.ld" % mcu_type
 
@@ -54,6 +56,8 @@ elif "f103r8" in mcu_type or "f103rb" in mcu_type:
     variant = "generic_stm32f103r8"
 elif "f103rc" in mcu_type or "f103re" in mcu_type:
     variant = "generic_stm32f103r"
+elif "f103t8" in mcu_type or "f103tb" in mcu_type:
+    variant = "generic_stm32f103t"
 elif "f103vc" in mcu_type or "f103ve" in mcu_type:
     variant = "generic_stm32f103v"
 
@@ -96,7 +100,7 @@ elif "nucleo_f103rb" in board.id:
 elif upload_protocol == "dfu":
     env.Append(CPPDEFINES=["SERIAL_USB", "GENERIC_BOOTLOADER"])
     vector = 0x8002000
-    if "f103c" in mcu_type:
+    if "f103c" in mcu_type or "f103t" in mcu_type:
         ldscript = "bootloader_20.ld"
     elif "f103r" in mcu_type and board.id != "maple_ret6":
         ldscript = "bootloader.ld"

--- a/builder/frameworks/arduino/maple/stm32f1.py
+++ b/builder/frameworks/arduino/maple/stm32f1.py
@@ -68,12 +68,18 @@ if upload_protocol not in ("dfu", "serial"):
         "GENERIC_BOOTLOADER"
     ])
 
-# maple board related configuration remap
-if "maple" in board.id:
+# maple and microduino board related configuration remap
+if "maple" in board.id or "microduino" in board.id:
     env.Append(CPPDEFINES=[("SERIAL_USB")])
-    variant = "maple_mini" if "maple_mini" in board.id else "maple"
     vector = 0x8005000
     ldscript = "flash.ld"
+    if "microduino" in board.id:
+        variant = "microduino"
+    elif "maple_mini" in board.id:
+        variant = "maple_mini"
+    else:
+        variant = "maple"
+
     if board.id == "maple_mini_b20":
         vector = 0x8002000
         ldscript = "bootloader_20.ld"
@@ -102,6 +108,8 @@ if "nucleo_f103rb" in board.id:
     board_type = "STM_NUCLEO_F103RB"
 elif "maple_ret6" in board.id:
     board_type = "MAPLE_RET6"
+elif "microduino" in board.id:
+    board_type = "MICRODUINO_CORE_STM32"
 
 env.Append(
     CFLAGS=["-std=gnu11"],

--- a/builder/frameworks/arduino/maple/stm32f1.py
+++ b/builder/frameworks/arduino/maple/stm32f1.py
@@ -77,6 +77,9 @@ if "maple" in board.id:
     if board.id == "maple_mini_b20":
         vector = 0x8002000
         ldscript = "bootloader_20.ld"
+    elif board.id == "maple_ret6":
+        variant = "maple_ret6"
+        ldscript = "stm32f103re-bootloader.ld"
 
 # for nucleo f103rb board
 elif "nucleo_f103rb" in board.id:
@@ -89,11 +92,16 @@ elif upload_protocol == "dfu":
     vector = 0x8002000
     if "f103c" in mcu_type:
         ldscript = "bootloader_20.ld"
-    elif "f103r" in mcu_type:
+    elif "f103r" in mcu_type and board.id != "maple_ret6":
         ldscript = "bootloader.ld"
     elif "f103v" in mcu_type:
         ldscript = "stm32f103veDFU.ld"
 
+board_type = variant
+if "nucleo_f103rb" in board.id:
+    board_type = "STM_NUCLEO_F103RB"
+elif "maple_ret6" in board.id:
+    board_type = "MAPLE_RET6"
 
 env.Append(
     CFLAGS=["-std=gnu11"],
@@ -113,8 +121,7 @@ env.Append(
         ("ERROR_LED_PORT", error_led_port),
         ("ERROR_LED_PIN", error_led_pin),
         ("ARDUINO", 10610),
-        ("ARDUINO_%s" % variant.upper()
-            if "nucleo" not in board.id else "STM_NUCLEO_F103RB"),
+        ("ARDUINO_%s" % board_type),
         ("ARDUINO_ARCH_STM32F1"),
         ("__STM32F1__"),
         ("MCU_%s" % mcu_type.upper())
@@ -124,6 +131,7 @@ env.Append(
         join(FRAMEWORK_DIR, "cores", "maple"),
         join(FRAMEWORK_DIR, "system", "libmaple"),
         join(FRAMEWORK_DIR, "system", "libmaple", "include"),
+        join(FRAMEWORK_DIR, "system", "libmaple", "stm32f1", "include"),
         join(FRAMEWORK_DIR, "system", "libmaple", "usb", "stm32f1"),
         join(FRAMEWORK_DIR, "system", "libmaple", "usb", "usb_lib")
     ],

--- a/builder/frameworks/arduino/maple/stm32f1.py
+++ b/builder/frameworks/arduino/maple/stm32f1.py
@@ -58,8 +58,14 @@ elif "f103rc" in mcu_type or "f103re" in mcu_type:
     variant = "generic_stm32f103r"
 elif "f103t8" in mcu_type or "f103tb" in mcu_type:
     variant = "generic_stm32f103t"
-elif "f103vc" in mcu_type or "f103ve" in mcu_type:
+elif "f103vb" in mcu_type:
+    variant = "generic_stm32f103vb"
+elif "f103vc" in mcu_type or "f103ve" in mcu_type or "f103vd" in mcu_type:
     variant = "generic_stm32f103v"
+
+if "f103v" in mcu_type:
+    error_led_port = "GPIOE"
+    error_led_pin = 6
 
 # upload related configuration remap
 # for all generic boards

--- a/builder/frameworks/arduino/maple/stm32f1.py
+++ b/builder/frameworks/arduino/maple/stm32f1.py
@@ -62,6 +62,8 @@ elif "f103vb" in mcu_type:
     variant = "generic_stm32f103vb"
 elif "f103vc" in mcu_type or "f103ve" in mcu_type or "f103vd" in mcu_type:
     variant = "generic_stm32f103v"
+elif "f103z" in mcu_type:
+    variant = "generic_stm32f103z"
 
 if "f103v" in mcu_type:
     error_led_port = "GPIOE"
@@ -112,6 +114,8 @@ elif upload_protocol == "dfu":
         ldscript = "bootloader.ld"
     elif "f103v" in mcu_type:
         ldscript = "stm32f103veDFU.ld"
+    elif "f103z" in mcu_type:
+        ldscript = "stm32f103z_dfu.ld"
 
 board_type = variant
 if "nucleo_f103rb" in board.id:

--- a/builder/frameworks/arduino/maple/stm32f1.py
+++ b/builder/frameworks/arduino/maple/stm32f1.py
@@ -110,7 +110,7 @@ elif upload_protocol == "dfu":
     vector = 0x8002000
     if "f103c" in mcu_type or "f103t" in mcu_type:
         ldscript = "bootloader_20.ld"
-    elif "f103r" in mcu_type and board.id != "maple_ret6":
+    elif "f103r" in mcu_type:
         ldscript = "bootloader.ld"
     elif "f103v" in mcu_type:
         ldscript = "stm32f103veDFU.ld"

--- a/builder/frameworks/stm32cube.py
+++ b/builder/frameworks/stm32cube.py
@@ -43,6 +43,7 @@ STARTUP_FILE_EXCEPTIONS = {
     "stm32f103c8": "startup_stm32f103xb.s",
     "stm32f103r8": "startup_stm32f103xb.s",
     "stm32f103rc": "startup_stm32f103xb.s",
+    "stm32f103t8": "startup_stm32f103xb.s",
     "stm32f103vc": "startup_stm32f103xe.s",
     "stm32f103ve": "startup_stm32f103xe.s",
     "stm32f407ve": "startup_stm32f407xx.s"

--- a/builder/frameworks/stm32cube.py
+++ b/builder/frameworks/stm32cube.py
@@ -150,7 +150,7 @@ env.Replace(
 if "build.extra_flags" in env.BoardConfig():
     _extra_flags = env.BoardConfig().get("build.extra_flags")
 
-    if "F103xC" in _extra_flags or "F103xD" in _extra_flags:
+    if "F103xC" in _extra_flags:
         _extra_flags = "-DSTM32F103xE"
     elif "F103x8" in _extra_flags:
         _extra_flags = "-DSTM32F103xB"

--- a/builder/frameworks/stm32cube.py
+++ b/builder/frameworks/stm32cube.py
@@ -47,6 +47,8 @@ STARTUP_FILE_EXCEPTIONS = {
     "stm32f103vc": "startup_stm32f103xe.s",
     "stm32f103vd": "startup_stm32f103xe.s",
     "stm32f103ve": "startup_stm32f103xe.s",
+    "stm32f103zc": "startup_stm32f103xe.s",
+    "stm32f103zd": "startup_stm32f103xe.s",
     "stm32f407ve": "startup_stm32f407xx.s"
 }
 

--- a/builder/frameworks/stm32cube.py
+++ b/builder/frameworks/stm32cube.py
@@ -45,6 +45,7 @@ STARTUP_FILE_EXCEPTIONS = {
     "stm32f103rc": "startup_stm32f103xb.s",
     "stm32f103t8": "startup_stm32f103xb.s",
     "stm32f103vc": "startup_stm32f103xe.s",
+    "stm32f103vd": "startup_stm32f103xe.s",
     "stm32f103ve": "startup_stm32f103xe.s",
     "stm32f407ve": "startup_stm32f407xx.s"
 }
@@ -147,7 +148,7 @@ env.Replace(
 if "build.extra_flags" in env.BoardConfig():
     _extra_flags = env.BoardConfig().get("build.extra_flags")
 
-    if "F103xC" in _extra_flags:
+    if "F103xC" in _extra_flags or "F103xD" in _extra_flags:
         _extra_flags = "-DSTM32F103xE"
     elif "F103x8" in _extra_flags:
         _extra_flags = "-DSTM32F103xB"


### PR DESCRIPTION
Added pretty much all of STM32F1xx boards from [Arduino Maple core](https://github.com/rogerclarkmelbourne/Arduino_STM32).

Also changed some extra flags, since those should follow STM32cube standard flags.