### PR TITLE
Add support for the ST Nucleo F439ZI board

### DIFF
--- a/boards/nucleo_f439zi.json
+++ b/boards/nucleo_f439zi.json
@@ -1,0 +1,41 @@
+{
+  "build": {
+    "cpu": "cortex-m4",
+    "extra_flags": "-DSTM32F439xx",
+    "f_cpu": "180000000L",
+    "mcu": "stm32f439zit6"
+  },
+  "connectivity": [
+    "can",
+    "ethernet"
+  ],
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "onboard_tools": [
+      "stlink"
+    ],
+    "openocd_board": "st_nucleo_f4",
+    "openocd_target": "stm32f4x",
+    "svd_path": "STM32F439x.svd"
+  },
+  "frameworks": [
+    "mbed",
+    "stm32cube"
+  ],
+  "name": "ST Nucleo F439ZI",
+  "upload": {
+    "maximum_ram_size": 262144,
+    "maximum_size": 2097152,
+    "protocol": "mbed",
+    "protocols": [
+      "jlink",
+      "stlink",
+      "blackmagic",
+      "mbed"
+    ]
+  },
+  "url": "https://developer.mbed.org/platforms/ST-Nucleo-F439ZI/",
+  "vendor": "ST"
+}


### PR DESCRIPTION
F439ZI is based on the F429ZI with additional HW crypto acceleration.