### PR TITLE
Allow -l flag in build_flags

### DIFF
--- a/builder/frameworks/arduino/mxchip.py
+++ b/builder/frameworks/arduino/mxchip.py
@@ -149,8 +149,6 @@ inc_dirs.extend([
 env.Append(CPPPATH=inc_dirs)
 
 env.Replace(
-    LIBS=["az_iot", "m", "wlan", "wifi", "libstsafe", "mbed-os", "stdc++", "gcc"],
-
     LINKFLAGS=[
         "-mcpu=cortex-m4",
         "-mthumb",
@@ -169,6 +167,8 @@ env.Replace(
         "-u", "_printf_float"
     ]
 )
+
+env.Prepend(LIBS=["az_iot", "m", "wlan", "wifi", "libstsafe", "mbed-os", "stdc++", "gcc"])
 
 #
 # Target: Build Core Library


### PR DESCRIPTION
Currently passing `-lmylib` in the build_flags of platformio.ini has no effect.  This change allows them to be passed to the compiler