### PR TITLE
define ARDUINO_BLUEPILL_F103C8 for bluepills to get correct LED_BUILTIN

### DIFF
--- a/boards/bluepill_f103c8.json
+++ b/boards/bluepill_f103c8.json
@@ -2,7 +2,7 @@
   "build": {
     "core": "stm32",
     "cpu": "cortex-m3",
-    "extra_flags": "-DSTM32F1 -DSTM32F103xB",
+    "extra_flags": "-DSTM32F1 -DSTM32F103xB -DARDUINO_BLUEPILL_F103C8",
     "f_cpu": "72000000L",
     "hwids": [
       [

--- a/boards/bluepill_f103c8_128k.json
+++ b/boards/bluepill_f103c8_128k.json
@@ -2,7 +2,7 @@
   "build": {
     "core": "stm32",
     "cpu": "cortex-m3",
-    "extra_flags": "-DSTM32F1 -DSTM32F103xB",
+    "extra_flags": "-DSTM32F1 -DSTM32F103xB -DARDUINO_BLUEPILL_F103C8",
     "f_cpu": "72000000L",
     "hwids": [
       [


### PR DESCRIPTION
See this check: https://github.com/stm32duino/Arduino_Core_STM32/blob/0337a22c139bf11de5d82707f3d6d6fa750019b7/variants/BLUEPILL_F103XX/variant.h#L94