### PR TITLE
Fix RAM size for 303k8

### DIFF
--- a/boards/nucleo_f303k8.json
+++ b/boards/nucleo_f303k8.json
@@ -27,7 +27,7 @@
   ],
   "name": "ST Nucleo F303K8",
   "upload": {
-    "maximum_ram_size": 16384,
+    "maximum_ram_size": 12288,
     "maximum_size": 65536,
     "protocol": "stlink",
     "protocols": [


### PR DESCRIPTION
the 303k8 has 12KBytes of RAM, not 16.
See [STM32F303K8](https://www.st.com/en/microcontrollers-microprocessors/stm32f303k8.html)