### PR TITLE
Add -DSTM32F405xx build flag for STM32F4Stamp and N2+ boards

### DIFF
--- a/boards/netduino2plus.json
+++ b/boards/netduino2plus.json
@@ -2,7 +2,7 @@
   "build": {
     "core": "maple",
     "cpu": "cortex-m4",
-    "extra_flags": "-DMCU_STM32F406VG -DBOARD_discovery_f4 -DARDUINO_Netduino2F405",
+    "extra_flags": "-DMCU_STM32F406VG -DBOARD_discovery_f4 -DARDUINO_Netduino2F405 -DSTM32F405xx",
     "f_cpu": "168000000L",
     "hwids": [
       [

--- a/boards/stm32f4stamp.json
+++ b/boards/stm32f4stamp.json
@@ -2,7 +2,7 @@
   "build": {
     "core": "maple",
     "cpu": "cortex-m4",
-    "extra_flags": "-DMCU_STM32F406VG -DBOARD_discovery_f4 -DARDUINO_STM32F4StampF405",
+    "extra_flags": "-DMCU_STM32F406VG -DBOARD_discovery_f4 -DARDUINO_STM32F4StampF405 -DSTM32F405xx",
     "f_cpu": "168000000L",
     "hwids": [
       [


### PR DESCRIPTION
Without this flag, I got an error while building STM32Cube blink example for STM32F405RGT6 
```
/home/unn4m3d/.platformio/packages/framework-stm32cube/f4/Drivers/CMSIS/Device/ST/STM32F4xx/Include/stm32f4xx.h:191:3: error: #error "Please select first the target STM32F4xx device used in your application (in stm32f4xx.h file)"
  #error "Please select first the target STM32F4xx device used in your application (in stm32f4xx.h file)"
   ^~~~~

<... ~5k lines of GCC errors ... >
``` 

Setting `build_flags = -DF4 -DSTM32F405xx` worked for me.