### PR TITLE
INVERTED SIZES IN CONFIg

### DIFF
--- a/boards/genericSTM32F103T8.json
+++ b/boards/genericSTM32F103T8.json
@@ -32,8 +32,8 @@
   "name": "STM32F103T8 (20k RAM. 64k Flash)",
   "upload": {
     "disable_flushing": false,
-    "maximum_ram_size": 65536,
-    "maximum_size": 20480,
+    "maximum_ram_size": 20480,
+    "maximum_size": 65536,
     "protocol": "stlink",
     "protocols": [
       "jlink",


### PR DESCRIPTION
64 Kbytes Flash
20 Kbytes of SRAM

ACTUAL
"maximum_ram_size": 65536,
"maximum_size": 20480,

FIXED
"maximum_ram_size": 20480,
"maximum_size": 65536,