### PR TITLE
Add cmsis framework to STM32F446ZE

### DIFF
--- a/boards/nucleo_f446ze.json
+++ b/boards/nucleo_f446ze.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "cpu": "cortex-m4",
-    "extra_flags": "-DSTM32F446xx",
+    "extra_flags": "-DSTM32F4 -DSTM32F446xx",
     "f_cpu": "180000000L",
     "mcu": "stm32f446zet6"
   },
@@ -20,6 +20,7 @@
     "svd_path": "STM32F446x.svd"
   },
   "frameworks": [
+    "cmsis",
     "mbed",
     "stm32cube"
   ],


### PR DESCRIPTION
STM32F446ZE supports stm32cube, which depend on cmsis.