### PR TITLE
fix invalid (missing) ldscript_cb.ld on libopencm3

### DIFF
--- a/boards/blackpill_f103c8_128.json
+++ b/boards/blackpill_f103c8_128.json
@@ -14,7 +14,7 @@
         "0x0004"
       ]
     ],
-    "ldscript": "ldscript_cb.ld",
+    "ldscript": "stm32f103xb.ld",
     "mcu": "stm32f103c8t6",
     "variant": "PILL_F103XX",
     "zephyr": {

--- a/boards/bluepill_f103c8_128k.json
+++ b/boards/bluepill_f103c8_128k.json
@@ -14,7 +14,7 @@
         "0x0004"
       ]
     ],
-    "ldscript": "ldscript_cb.ld",
+    "ldscript": "stm32f103xb.ld",
     "mcu": "stm32f103c8t6",
     "variant": "PILL_F103XX",
     "zephyr": {


### PR DESCRIPTION
ldscript_cb.ld does not exist in libopencm3 and thus bluepill and blackpill 128 will not link (in libopencm3)

Either change it here to stm32f103xb.ld or create a ldscript_cb.ld in libopencm3