### PR TITLE
added board Adafruit STM32F405Express Feather

### DIFF
--- a/boards/adafruit-stm32f405express-feather.json
+++ b/boards/adafruit-stm32f405express-feather.json
@@ -1,0 +1,49 @@
+{
+  "build": {
+    "core": "maple",
+    "cpu": "cortex-m4",
+    "extra_flags": "-DMCU_STM32F406VG -DBOARD_discovery_f4 -DARDUINO_STM32F4StampF405 -DSTM32F405xx",
+    "f_cpu": "168000000L",
+    "hwids": [
+      [
+        "0x0483",
+        "0xDF11"
+      ]
+    ],
+    "mcu": "stm32f405rgt6",
+    "variant": "stm32f4"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32F405RG",
+    "openocd_extra_args": [
+      "-c",
+      "reset_config none"
+    ],
+    "openocd_target": "stm32f4x",
+    "svd_path": "STM32F40x.svd"
+  },
+  "frameworks": [
+    "arduino",
+    "stm32cube"
+  ],
+  "name": "STM32F405 Feather Express",
+  "upload": {
+    "disable_flushing": false,
+    "maximum_ram_size": 196608,
+    "maximum_size": 1048576,
+    "protocol": "dfu",
+    "protocols": [
+      "stlink",
+      "dfu",
+      "jlink"
+    ],
+    "require_upload_port": true,
+    "use_1200bps_touch": false,
+    "wait_for_upload_port": false
+  },
+  "url": "https://learn.adafruit.com/adafruit-stm32f405-feather-express",
+  "vendor": "Adafruit"
+}


### PR DESCRIPTION
The Adafruit STM32F405Express Feather is basically the same thing as the stm32f4stamp. I was able to use the stm32f4stamp board to build/run the Arduino Blink example on my feather (needed to change the pin but that's it). I'm not sure what effect the -DARDUINO_STM32F4StampF405 build flag has. 