### PR TITLE
Initial support for STM32G0

### DIFF
--- a/boards/genericSTM32G030C6.json
+++ b/boards/genericSTM32G030C6.json
@@ -25,7 +25,10 @@
     "maximum_size": 32768,
     "protocol": "stlink",
     "protocols": [
-      "stlink"
+      "jlink",
+      "stlink",
+      "blackmagic",
+      "serial"
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,

--- a/boards/genericSTM32G030C6.json
+++ b/boards/genericSTM32G030C6.json
@@ -1,0 +1,36 @@
+{
+  "build": {
+    "core": "maple",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DSTM32G0xx -DSTM32G030xx",
+    "f_cpu": "64000000L",
+    "mcu": "stm32g030c6",
+    "variant": "stm32g0"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32G030C6",
+    "openocd_target": "stm32g0x",
+    "svd_path": "STM32G030.svd"
+  },
+  "frameworks": [
+    "stm32cube"
+  ],
+  "name": "STM32G030C6 (8k RAM. 32k Flash)",
+  "upload": {
+    "disable_flushing": false,
+    "maximum_ram_size": 8192,
+    "maximum_size": 32768,
+    "protocol": "stlink",
+    "protocols": [
+      "stlink"
+    ],
+    "require_upload_port": true,
+    "use_1200bps_touch": false,
+    "wait_for_upload_port": false
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32g030c6.html",
+  "vendor": "ST"
+}

--- a/boards/genericSTM32G030C8.json
+++ b/boards/genericSTM32G030C8.json
@@ -25,7 +25,10 @@
     "maximum_size": 65536,
     "protocol": "stlink",
     "protocols": [
-      "stlink"
+      "jlink",
+      "stlink",
+      "blackmagic",
+      "serial"
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,

--- a/boards/genericSTM32G030C8.json
+++ b/boards/genericSTM32G030C8.json
@@ -1,0 +1,36 @@
+{
+  "build": {
+    "core": "maple",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DSTM32G0xx -DSTM32G030xx",
+    "f_cpu": "64000000L",
+    "mcu": "stm32g030c8",
+    "variant": "stm32g0"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32G030C8",
+    "openocd_target": "stm32g0x",
+    "svd_path": "STM32G030.svd"
+  },
+  "frameworks": [
+    "stm32cube"
+  ],
+  "name": "STM32G030C8 (8k RAM. 64k Flash)",
+  "upload": {
+    "disable_flushing": false,
+    "maximum_ram_size": 8192,
+    "maximum_size": 65536,
+    "protocol": "stlink",
+    "protocols": [
+      "stlink"
+    ],
+    "require_upload_port": true,
+    "use_1200bps_touch": false,
+    "wait_for_upload_port": false
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32g030c8.html",
+  "vendor": "ST"
+}

--- a/boards/genericSTM32G030F6.json
+++ b/boards/genericSTM32G030F6.json
@@ -25,7 +25,10 @@
     "maximum_size": 32768,
     "protocol": "stlink",
     "protocols": [
-      "stlink"
+      "jlink",
+      "stlink",
+      "blackmagic",
+      "serial"
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,

--- a/boards/genericSTM32G030F6.json
+++ b/boards/genericSTM32G030F6.json
@@ -1,0 +1,36 @@
+{
+  "build": {
+    "core": "maple",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DSTM32G0xx -DSTM32G030xx",
+    "f_cpu": "64000000L",
+    "mcu": "stm32g030f6",
+    "variant": "stm32g0"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32G030F6",
+    "openocd_target": "stm32g0x",
+    "svd_path": "STM32G030.svd"
+  },
+  "frameworks": [
+    "stm32cube"
+  ],
+  "name": "STM32G030F6 (8k RAM. 32k Flash)",
+  "upload": {
+    "disable_flushing": false,
+    "maximum_ram_size": 8192,
+    "maximum_size": 32768,
+    "protocol": "stlink",
+    "protocols": [
+      "stlink"
+    ],
+    "require_upload_port": true,
+    "use_1200bps_touch": false,
+    "wait_for_upload_port": false
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32g030f6.html",
+  "vendor": "ST"
+}

--- a/boards/genericSTM32G030J6.json
+++ b/boards/genericSTM32G030J6.json
@@ -1,0 +1,36 @@
+{
+  "build": {
+    "core": "maple",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DSTM32G0xx -DSTM32G030xx",
+    "f_cpu": "64000000L",
+    "mcu": "stm32g030j6",
+    "variant": "stm32g0"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32G030J6",
+    "openocd_target": "stm32g0x",
+    "svd_path": "STM32G030.svd"
+  },
+  "frameworks": [
+    "stm32cube"
+  ],
+  "name": "STM32G030J6 (8k RAM. 32k Flash)",
+  "upload": {
+    "disable_flushing": false,
+    "maximum_ram_size": 8192,
+    "maximum_size": 32768,
+    "protocol": "stlink",
+    "protocols": [
+      "stlink"
+    ],
+    "require_upload_port": true,
+    "use_1200bps_touch": false,
+    "wait_for_upload_port": false
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32g030j6.html",
+  "vendor": "ST"
+}

--- a/boards/genericSTM32G030J6.json
+++ b/boards/genericSTM32G030J6.json
@@ -25,7 +25,10 @@
     "maximum_size": 32768,
     "protocol": "stlink",
     "protocols": [
-      "stlink"
+      "jlink",
+      "stlink",
+      "blackmagic",
+      "serial"
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,

--- a/boards/genericSTM32G030K6.json
+++ b/boards/genericSTM32G030K6.json
@@ -25,7 +25,10 @@
     "maximum_size": 32768,
     "protocol": "stlink",
     "protocols": [
-      "stlink"
+      "jlink",
+      "stlink",
+      "blackmagic",
+      "serial"
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,

--- a/boards/genericSTM32G030K6.json
+++ b/boards/genericSTM32G030K6.json
@@ -1,0 +1,36 @@
+{
+  "build": {
+    "core": "maple",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DSTM32G0xx -DSTM32G030xx",
+    "f_cpu": "64000000L",
+    "mcu": "stm32g030k6",
+    "variant": "stm32g0"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32G030K6",
+    "openocd_target": "stm32g0x",
+    "svd_path": "STM32G030.svd"
+  },
+  "frameworks": [
+    "stm32cube"
+  ],
+  "name": "STM32G030K6 (8k RAM. 32k Flash)",
+  "upload": {
+    "disable_flushing": false,
+    "maximum_ram_size": 8192,
+    "maximum_size": 32768,
+    "protocol": "stlink",
+    "protocols": [
+      "stlink"
+    ],
+    "require_upload_port": true,
+    "use_1200bps_touch": false,
+    "wait_for_upload_port": false
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32g030k6.html",
+  "vendor": "ST"
+}

--- a/boards/genericSTM32G030K8.json
+++ b/boards/genericSTM32G030K8.json
@@ -25,7 +25,10 @@
     "maximum_size": 65536,
     "protocol": "stlink",
     "protocols": [
-      "stlink"
+      "jlink",
+      "stlink",
+      "blackmagic",
+      "serial"
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,

--- a/boards/genericSTM32G030K8.json
+++ b/boards/genericSTM32G030K8.json
@@ -1,0 +1,36 @@
+{
+  "build": {
+    "core": "maple",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DSTM32G0xx -DSTM32G030xx",
+    "f_cpu": "64000000L",
+    "mcu": "stm32g030k8",
+    "variant": "stm32g0"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32G030K8",
+    "openocd_target": "stm32g0x",
+    "svd_path": "STM32G030.svd"
+  },
+  "frameworks": [
+    "stm32cube"
+  ],
+  "name": "STM32G030K8 (8k RAM. 64k Flash)",
+  "upload": {
+    "disable_flushing": false,
+    "maximum_ram_size": 8192,
+    "maximum_size": 65536,
+    "protocol": "stlink",
+    "protocols": [
+      "stlink"
+    ],
+    "require_upload_port": true,
+    "use_1200bps_touch": false,
+    "wait_for_upload_port": false
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32g030k8.html",
+  "vendor": "ST"
+}

--- a/boards/genericSTM32G031C4.json
+++ b/boards/genericSTM32G031C4.json
@@ -1,0 +1,36 @@
+{
+  "build": {
+    "core": "maple",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DSTM32G0xx -DSTM32G031xx",
+    "f_cpu": "64000000L",
+    "mcu": "stm32g031c4",
+    "variant": "stm32g0"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32G031C4",
+    "openocd_target": "stm32g0x",
+    "svd_path": "STM32G031.svd"
+  },
+  "frameworks": [
+    "stm32cube"
+  ],
+  "name": "STM32G031C4 (8k RAM. 16k Flash)",
+  "upload": {
+    "disable_flushing": false,
+    "maximum_ram_size": 8192,
+    "maximum_size": 16384,
+    "protocol": "stlink",
+    "protocols": [
+      "stlink"
+    ],
+    "require_upload_port": true,
+    "use_1200bps_touch": false,
+    "wait_for_upload_port": false
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32g031c4.html",
+  "vendor": "ST"
+}

--- a/boards/genericSTM32G031C4.json
+++ b/boards/genericSTM32G031C4.json
@@ -25,7 +25,10 @@
     "maximum_size": 16384,
     "protocol": "stlink",
     "protocols": [
-      "stlink"
+      "jlink",
+      "stlink",
+      "blackmagic",
+      "serial"
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,

--- a/boards/genericSTM32G031C6.json
+++ b/boards/genericSTM32G031C6.json
@@ -25,7 +25,10 @@
     "maximum_size": 32768,
     "protocol": "stlink",
     "protocols": [
-      "stlink"
+      "jlink",
+      "stlink",
+      "blackmagic",
+      "serial"
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,

--- a/boards/genericSTM32G031C6.json
+++ b/boards/genericSTM32G031C6.json
@@ -1,0 +1,36 @@
+{
+  "build": {
+    "core": "maple",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DSTM32G0xx -DSTM32G031xx",
+    "f_cpu": "64000000L",
+    "mcu": "stm32g031c6",
+    "variant": "stm32g0"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32G031C6",
+    "openocd_target": "stm32g0x",
+    "svd_path": "STM32G031.svd"
+  },
+  "frameworks": [
+    "stm32cube"
+  ],
+  "name": "STM32G031C6 (8k RAM. 32k Flash)",
+  "upload": {
+    "disable_flushing": false,
+    "maximum_ram_size": 8192,
+    "maximum_size": 32768,
+    "protocol": "stlink",
+    "protocols": [
+      "stlink"
+    ],
+    "require_upload_port": true,
+    "use_1200bps_touch": false,
+    "wait_for_upload_port": false
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32g031c6.html",
+  "vendor": "ST"
+}

--- a/boards/genericSTM32G031C8.json
+++ b/boards/genericSTM32G031C8.json
@@ -1,0 +1,36 @@
+{
+  "build": {
+    "core": "maple",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DSTM32G0xx -DSTM32G031xx",
+    "f_cpu": "64000000L",
+    "mcu": "stm32g031c8",
+    "variant": "stm32g0"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32G031C8",
+    "openocd_target": "stm32g0x",
+    "svd_path": "STM32G031.svd"
+  },
+  "frameworks": [
+    "stm32cube"
+  ],
+  "name": "STM32G031C8 (8k RAM. 64k Flash)",
+  "upload": {
+    "disable_flushing": false,
+    "maximum_ram_size": 8192,
+    "maximum_size": 65536,
+    "protocol": "stlink",
+    "protocols": [
+      "stlink"
+    ],
+    "require_upload_port": true,
+    "use_1200bps_touch": false,
+    "wait_for_upload_port": false
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32g031c8.html",
+  "vendor": "ST"
+}

--- a/boards/genericSTM32G031C8.json
+++ b/boards/genericSTM32G031C8.json
@@ -25,7 +25,10 @@
     "maximum_size": 65536,
     "protocol": "stlink",
     "protocols": [
-      "stlink"
+      "jlink",
+      "stlink",
+      "blackmagic",
+      "serial"
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,

--- a/boards/genericSTM32G031F4.json
+++ b/boards/genericSTM32G031F4.json
@@ -1,0 +1,36 @@
+{
+  "build": {
+    "core": "maple",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DSTM32G0xx -DSTM32G031xx",
+    "f_cpu": "64000000L",
+    "mcu": "stm32g031f4",
+    "variant": "stm32g0"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32G031F4",
+    "openocd_target": "stm32g0x",
+    "svd_path": "STM32G031.svd"
+  },
+  "frameworks": [
+    "stm32cube"
+  ],
+  "name": "STM32G031F4 (8k RAM. 16k Flash)",
+  "upload": {
+    "disable_flushing": false,
+    "maximum_ram_size": 8192,
+    "maximum_size": 16384,
+    "protocol": "stlink",
+    "protocols": [
+      "stlink"
+    ],
+    "require_upload_port": true,
+    "use_1200bps_touch": false,
+    "wait_for_upload_port": false
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32g031f4.html",
+  "vendor": "ST"
+}

--- a/boards/genericSTM32G031F4.json
+++ b/boards/genericSTM32G031F4.json
@@ -25,7 +25,10 @@
     "maximum_size": 16384,
     "protocol": "stlink",
     "protocols": [
-      "stlink"
+      "jlink",
+      "stlink",
+      "blackmagic",
+      "serial"
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,

--- a/boards/genericSTM32G031F6.json
+++ b/boards/genericSTM32G031F6.json
@@ -1,0 +1,36 @@
+{
+  "build": {
+    "core": "maple",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DSTM32G0xx -DSTM32G031xx",
+    "f_cpu": "64000000L",
+    "mcu": "stm32g031f6",
+    "variant": "stm32g0"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32G031F6",
+    "openocd_target": "stm32g0x",
+    "svd_path": "STM32G031.svd"
+  },
+  "frameworks": [
+    "stm32cube"
+  ],
+  "name": "STM32G031F6 (8k RAM. 32k Flash)",
+  "upload": {
+    "disable_flushing": false,
+    "maximum_ram_size": 8192,
+    "maximum_size": 32768,
+    "protocol": "stlink",
+    "protocols": [
+      "stlink"
+    ],
+    "require_upload_port": true,
+    "use_1200bps_touch": false,
+    "wait_for_upload_port": false
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32g031f6.html",
+  "vendor": "ST"
+}

--- a/boards/genericSTM32G031F6.json
+++ b/boards/genericSTM32G031F6.json
@@ -25,7 +25,10 @@
     "maximum_size": 32768,
     "protocol": "stlink",
     "protocols": [
-      "stlink"
+      "jlink",
+      "stlink",
+      "blackmagic",
+      "serial"
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,

--- a/boards/genericSTM32G031F8.json
+++ b/boards/genericSTM32G031F8.json
@@ -1,0 +1,36 @@
+{
+  "build": {
+    "core": "maple",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DSTM32G0xx -DSTM32G031xx",
+    "f_cpu": "64000000L",
+    "mcu": "stm32g031f8",
+    "variant": "stm32g0"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32G031F8",
+    "openocd_target": "stm32g0x",
+    "svd_path": "STM32G031.svd"
+  },
+  "frameworks": [
+    "stm32cube"
+  ],
+  "name": "STM32G031F8 (8k RAM. 64k Flash)",
+  "upload": {
+    "disable_flushing": false,
+    "maximum_ram_size": 8192,
+    "maximum_size": 65536,
+    "protocol": "stlink",
+    "protocols": [
+      "stlink"
+    ],
+    "require_upload_port": true,
+    "use_1200bps_touch": false,
+    "wait_for_upload_port": false
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32g031f8.html",
+  "vendor": "ST"
+}

--- a/boards/genericSTM32G031F8.json
+++ b/boards/genericSTM32G031F8.json
@@ -25,7 +25,10 @@
     "maximum_size": 65536,
     "protocol": "stlink",
     "protocols": [
-      "stlink"
+      "jlink",
+      "stlink",
+      "blackmagic",
+      "serial"
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,

--- a/boards/genericSTM32G031G4.json
+++ b/boards/genericSTM32G031G4.json
@@ -1,0 +1,36 @@
+{
+  "build": {
+    "core": "maple",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DSTM32G0xx -DSTM32G031xx",
+    "f_cpu": "64000000L",
+    "mcu": "stm32g031g4",
+    "variant": "stm32g0"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32G031G4",
+    "openocd_target": "stm32g0x",
+    "svd_path": "STM32G031.svd"
+  },
+  "frameworks": [
+    "stm32cube"
+  ],
+  "name": "STM32G031G4 (8k RAM. 16k Flash)",
+  "upload": {
+    "disable_flushing": false,
+    "maximum_ram_size": 8192,
+    "maximum_size": 16384,
+    "protocol": "stlink",
+    "protocols": [
+      "stlink"
+    ],
+    "require_upload_port": true,
+    "use_1200bps_touch": false,
+    "wait_for_upload_port": false
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32g031g4.html",
+  "vendor": "ST"
+}

--- a/boards/genericSTM32G031G4.json
+++ b/boards/genericSTM32G031G4.json
@@ -25,7 +25,10 @@
     "maximum_size": 16384,
     "protocol": "stlink",
     "protocols": [
-      "stlink"
+      "jlink",
+      "stlink",
+      "blackmagic",
+      "serial"
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,

--- a/boards/genericSTM32G031G6.json
+++ b/boards/genericSTM32G031G6.json
@@ -1,0 +1,36 @@
+{
+  "build": {
+    "core": "maple",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DSTM32G0xx -DSTM32G031xx",
+    "f_cpu": "64000000L",
+    "mcu": "stm32g031g6",
+    "variant": "stm32g0"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32G031G6",
+    "openocd_target": "stm32g0x",
+    "svd_path": "STM32G031.svd"
+  },
+  "frameworks": [
+    "stm32cube"
+  ],
+  "name": "STM32G031G6 (8k RAM. 32k Flash)",
+  "upload": {
+    "disable_flushing": false,
+    "maximum_ram_size": 8192,
+    "maximum_size": 32768,
+    "protocol": "stlink",
+    "protocols": [
+      "stlink"
+    ],
+    "require_upload_port": true,
+    "use_1200bps_touch": false,
+    "wait_for_upload_port": false
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32g031g6.html",
+  "vendor": "ST"
+}

--- a/boards/genericSTM32G031G6.json
+++ b/boards/genericSTM32G031G6.json
@@ -25,7 +25,10 @@
     "maximum_size": 32768,
     "protocol": "stlink",
     "protocols": [
-      "stlink"
+      "jlink",
+      "stlink",
+      "blackmagic",
+      "serial"
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,

--- a/boards/genericSTM32G031G8.json
+++ b/boards/genericSTM32G031G8.json
@@ -1,0 +1,36 @@
+{
+  "build": {
+    "core": "maple",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DSTM32G0xx -DSTM32G031xx",
+    "f_cpu": "64000000L",
+    "mcu": "stm32g031g8",
+    "variant": "stm32g0"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32G031G8",
+    "openocd_target": "stm32g0x",
+    "svd_path": "STM32G031.svd"
+  },
+  "frameworks": [
+    "stm32cube"
+  ],
+  "name": "STM32G031G8 (8k RAM. 64k Flash)",
+  "upload": {
+    "disable_flushing": false,
+    "maximum_ram_size": 8192,
+    "maximum_size": 65536,
+    "protocol": "stlink",
+    "protocols": [
+      "stlink"
+    ],
+    "require_upload_port": true,
+    "use_1200bps_touch": false,
+    "wait_for_upload_port": false
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32g031g8.html",
+  "vendor": "ST"
+}

--- a/boards/genericSTM32G031G8.json
+++ b/boards/genericSTM32G031G8.json
@@ -25,7 +25,10 @@
     "maximum_size": 65536,
     "protocol": "stlink",
     "protocols": [
-      "stlink"
+      "jlink",
+      "stlink",
+      "blackmagic",
+      "serial"
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,

--- a/boards/genericSTM32G031J4.json
+++ b/boards/genericSTM32G031J4.json
@@ -1,0 +1,36 @@
+{
+  "build": {
+    "core": "maple",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DSTM32G0xx -DSTM32G031xx",
+    "f_cpu": "64000000L",
+    "mcu": "stm32g031j4",
+    "variant": "stm32g0"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32G031J4",
+    "openocd_target": "stm32g0x",
+    "svd_path": "STM32G031.svd"
+  },
+  "frameworks": [
+    "stm32cube"
+  ],
+  "name": "STM32G031J4 (8k RAM. 16k Flash)",
+  "upload": {
+    "disable_flushing": false,
+    "maximum_ram_size": 8192,
+    "maximum_size": 16384,
+    "protocol": "stlink",
+    "protocols": [
+      "stlink"
+    ],
+    "require_upload_port": true,
+    "use_1200bps_touch": false,
+    "wait_for_upload_port": false
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32g031j4.html",
+  "vendor": "ST"
+}

--- a/boards/genericSTM32G031J4.json
+++ b/boards/genericSTM32G031J4.json
@@ -25,7 +25,10 @@
     "maximum_size": 16384,
     "protocol": "stlink",
     "protocols": [
-      "stlink"
+      "jlink",
+      "stlink",
+      "blackmagic",
+      "serial"
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,

--- a/boards/genericSTM32G031J6.json
+++ b/boards/genericSTM32G031J6.json
@@ -25,7 +25,10 @@
     "maximum_size": 32768,
     "protocol": "stlink",
     "protocols": [
-      "stlink"
+      "jlink",
+      "stlink",
+      "blackmagic",
+      "serial"
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,

--- a/boards/genericSTM32G031J6.json
+++ b/boards/genericSTM32G031J6.json
@@ -1,0 +1,36 @@
+{
+  "build": {
+    "core": "maple",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DSTM32G0xx -DSTM32G031xx",
+    "f_cpu": "64000000L",
+    "mcu": "stm32g031j6",
+    "variant": "stm32g0"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32G031J6",
+    "openocd_target": "stm32g0x",
+    "svd_path": "STM32G031.svd"
+  },
+  "frameworks": [
+    "stm32cube"
+  ],
+  "name": "STM32G031J6 (8k RAM. 32k Flash)",
+  "upload": {
+    "disable_flushing": false,
+    "maximum_ram_size": 8192,
+    "maximum_size": 32768,
+    "protocol": "stlink",
+    "protocols": [
+      "stlink"
+    ],
+    "require_upload_port": true,
+    "use_1200bps_touch": false,
+    "wait_for_upload_port": false
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32g031j6.html",
+  "vendor": "ST"
+}

--- a/boards/genericSTM32G031K4.json
+++ b/boards/genericSTM32G031K4.json
@@ -25,7 +25,10 @@
     "maximum_size": 16384,
     "protocol": "stlink",
     "protocols": [
-      "stlink"
+      "jlink",
+      "stlink",
+      "blackmagic",
+      "serial"
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,

--- a/boards/genericSTM32G031K4.json
+++ b/boards/genericSTM32G031K4.json
@@ -1,0 +1,36 @@
+{
+  "build": {
+    "core": "maple",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DSTM32G0xx -DSTM32G031xx",
+    "f_cpu": "64000000L",
+    "mcu": "stm32g031k4",
+    "variant": "stm32g0"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32G031K4",
+    "openocd_target": "stm32g0x",
+    "svd_path": "STM32G031.svd"
+  },
+  "frameworks": [
+    "stm32cube"
+  ],
+  "name": "STM32G031K4 (8k RAM. 16k Flash)",
+  "upload": {
+    "disable_flushing": false,
+    "maximum_ram_size": 8192,
+    "maximum_size": 16384,
+    "protocol": "stlink",
+    "protocols": [
+      "stlink"
+    ],
+    "require_upload_port": true,
+    "use_1200bps_touch": false,
+    "wait_for_upload_port": false
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32g031k4.html",
+  "vendor": "ST"
+}

--- a/boards/genericSTM32G031K6.json
+++ b/boards/genericSTM32G031K6.json
@@ -1,0 +1,36 @@
+{
+  "build": {
+    "core": "maple",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DSTM32G0xx -DSTM32G031xx",
+    "f_cpu": "64000000L",
+    "mcu": "stm32g031k6",
+    "variant": "stm32g0"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32G031K6",
+    "openocd_target": "stm32g0x",
+    "svd_path": "STM32G031.svd"
+  },
+  "frameworks": [
+    "stm32cube"
+  ],
+  "name": "STM32G031K6 (8k RAM. 32k Flash)",
+  "upload": {
+    "disable_flushing": false,
+    "maximum_ram_size": 8192,
+    "maximum_size": 32768,
+    "protocol": "stlink",
+    "protocols": [
+      "stlink"
+    ],
+    "require_upload_port": true,
+    "use_1200bps_touch": false,
+    "wait_for_upload_port": false
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32g031k6.html",
+  "vendor": "ST"
+}

--- a/boards/genericSTM32G031K6.json
+++ b/boards/genericSTM32G031K6.json
@@ -25,7 +25,10 @@
     "maximum_size": 32768,
     "protocol": "stlink",
     "protocols": [
-      "stlink"
+      "jlink",
+      "stlink",
+      "blackmagic",
+      "serial"
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,

--- a/boards/genericSTM32G031K8.json
+++ b/boards/genericSTM32G031K8.json
@@ -1,0 +1,36 @@
+{
+  "build": {
+    "core": "maple",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DSTM32G0xx -DSTM32G031xx",
+    "f_cpu": "64000000L",
+    "mcu": "stm32g031k8",
+    "variant": "stm32g0"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32G031K8",
+    "openocd_target": "stm32g0x",
+    "svd_path": "STM32G031.svd"
+  },
+  "frameworks": [
+    "stm32cube"
+  ],
+  "name": "STM32G031K8 (8k RAM. 64k Flash)",
+  "upload": {
+    "disable_flushing": false,
+    "maximum_ram_size": 8192,
+    "maximum_size": 65536,
+    "protocol": "stlink",
+    "protocols": [
+      "stlink"
+    ],
+    "require_upload_port": true,
+    "use_1200bps_touch": false,
+    "wait_for_upload_port": false
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32g031k8.html",
+  "vendor": "ST"
+}

--- a/boards/genericSTM32G031K8.json
+++ b/boards/genericSTM32G031K8.json
@@ -25,7 +25,10 @@
     "maximum_size": 65536,
     "protocol": "stlink",
     "protocols": [
-      "stlink"
+      "jlink",
+      "stlink",
+      "blackmagic",
+      "serial"
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,

--- a/boards/genericSTM32G031Y8.json
+++ b/boards/genericSTM32G031Y8.json
@@ -1,0 +1,36 @@
+{
+  "build": {
+    "core": "maple",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DSTM32G0xx -DSTM32G031xx",
+    "f_cpu": "64000000L",
+    "mcu": "stm32g031y8",
+    "variant": "stm32g0"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32G031Y8",
+    "openocd_target": "stm32g0x",
+    "svd_path": "STM32G031.svd"
+  },
+  "frameworks": [
+    "stm32cube"
+  ],
+  "name": "STM32G031Y8 (8k RAM. 64k Flash)",
+  "upload": {
+    "disable_flushing": false,
+    "maximum_ram_size": 8192,
+    "maximum_size": 65536,
+    "protocol": "stlink",
+    "protocols": [
+      "stlink"
+    ],
+    "require_upload_port": true,
+    "use_1200bps_touch": false,
+    "wait_for_upload_port": false
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32g031y8.html",
+  "vendor": "ST"
+}

--- a/boards/genericSTM32G031Y8.json
+++ b/boards/genericSTM32G031Y8.json
@@ -25,7 +25,10 @@
     "maximum_size": 65536,
     "protocol": "stlink",
     "protocols": [
-      "stlink"
+      "jlink",
+      "stlink",
+      "blackmagic",
+      "serial"
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,

--- a/boards/genericSTM32G041C6.json
+++ b/boards/genericSTM32G041C6.json
@@ -1,0 +1,36 @@
+{
+  "build": {
+    "core": "maple",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DSTM32G0xx -DSTM32G041xx",
+    "f_cpu": "64000000L",
+    "mcu": "stm32g041c6",
+    "variant": "stm32g0"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32G041C6",
+    "openocd_target": "stm32g0x",
+    "svd_path": "STM32G041.svd"
+  },
+  "frameworks": [
+    "stm32cube"
+  ],
+  "name": "STM32G041C6 (8k RAM. 64k Flash)",
+  "upload": {
+    "disable_flushing": false,
+    "maximum_ram_size": 8192,
+    "maximum_size": 65536,
+    "protocol": "stlink",
+    "protocols": [
+      "stlink"
+    ],
+    "require_upload_port": true,
+    "use_1200bps_touch": false,
+    "wait_for_upload_port": false
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32g041c6.html",
+  "vendor": "ST"
+}

--- a/boards/genericSTM32G041C6.json
+++ b/boards/genericSTM32G041C6.json
@@ -25,7 +25,10 @@
     "maximum_size": 65536,
     "protocol": "stlink",
     "protocols": [
-      "stlink"
+      "jlink",
+      "stlink",
+      "blackmagic",
+      "serial"
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,

--- a/boards/genericSTM32G041C8.json
+++ b/boards/genericSTM32G041C8.json
@@ -1,0 +1,36 @@
+{
+  "build": {
+    "core": "maple",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DSTM32G0xx -DSTM32G041xx",
+    "f_cpu": "64000000L",
+    "mcu": "stm32g041c8",
+    "variant": "stm32g0"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32G041C8",
+    "openocd_target": "stm32g0x",
+    "svd_path": "STM32G041.svd"
+  },
+  "frameworks": [
+    "stm32cube"
+  ],
+  "name": "STM32G041C8 (8k RAM. 64k Flash)",
+  "upload": {
+    "disable_flushing": false,
+    "maximum_ram_size": 8192,
+    "maximum_size": 65536,
+    "protocol": "stlink",
+    "protocols": [
+      "stlink"
+    ],
+    "require_upload_port": true,
+    "use_1200bps_touch": false,
+    "wait_for_upload_port": false
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32g041c8.html",
+  "vendor": "ST"
+}

--- a/boards/genericSTM32G041C8.json
+++ b/boards/genericSTM32G041C8.json
@@ -25,7 +25,10 @@
     "maximum_size": 65536,
     "protocol": "stlink",
     "protocols": [
-      "stlink"
+      "jlink",
+      "stlink",
+      "blackmagic",
+      "serial"
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,

--- a/boards/genericSTM32G041F6.json
+++ b/boards/genericSTM32G041F6.json
@@ -1,0 +1,36 @@
+{
+  "build": {
+    "core": "maple",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DSTM32G0xx -DSTM32G041xx",
+    "f_cpu": "64000000L",
+    "mcu": "stm32g041f6",
+    "variant": "stm32g0"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32G041F6",
+    "openocd_target": "stm32g0x",
+    "svd_path": "STM32G041.svd"
+  },
+  "frameworks": [
+    "stm32cube"
+  ],
+  "name": "STM32G041F6 (8k RAM. 64k Flash)",
+  "upload": {
+    "disable_flushing": false,
+    "maximum_ram_size": 8192,
+    "maximum_size": 65536,
+    "protocol": "stlink",
+    "protocols": [
+      "stlink"
+    ],
+    "require_upload_port": true,
+    "use_1200bps_touch": false,
+    "wait_for_upload_port": false
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32g041f6.html",
+  "vendor": "ST"
+}

--- a/boards/genericSTM32G041F6.json
+++ b/boards/genericSTM32G041F6.json
@@ -25,7 +25,10 @@
     "maximum_size": 65536,
     "protocol": "stlink",
     "protocols": [
-      "stlink"
+      "jlink",
+      "stlink",
+      "blackmagic",
+      "serial"
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,

--- a/boards/genericSTM32G041F8.json
+++ b/boards/genericSTM32G041F8.json
@@ -1,0 +1,36 @@
+{
+  "build": {
+    "core": "maple",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DSTM32G0xx -DSTM32G041xx",
+    "f_cpu": "64000000L",
+    "mcu": "stm32g041f8",
+    "variant": "stm32g0"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32G041F8",
+    "openocd_target": "stm32g0x",
+    "svd_path": "STM32G041.svd"
+  },
+  "frameworks": [
+    "stm32cube"
+  ],
+  "name": "STM32G041F8 (8k RAM. 64k Flash)",
+  "upload": {
+    "disable_flushing": false,
+    "maximum_ram_size": 8192,
+    "maximum_size": 65536,
+    "protocol": "stlink",
+    "protocols": [
+      "stlink"
+    ],
+    "require_upload_port": true,
+    "use_1200bps_touch": false,
+    "wait_for_upload_port": false
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32g041f8.html",
+  "vendor": "ST"
+}

--- a/boards/genericSTM32G041F8.json
+++ b/boards/genericSTM32G041F8.json
@@ -25,7 +25,10 @@
     "maximum_size": 65536,
     "protocol": "stlink",
     "protocols": [
-      "stlink"
+      "jlink",
+      "stlink",
+      "blackmagic",
+      "serial"
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,

--- a/boards/genericSTM32G041G6.json
+++ b/boards/genericSTM32G041G6.json
@@ -1,0 +1,36 @@
+{
+  "build": {
+    "core": "maple",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DSTM32G0xx -DSTM32G041xx",
+    "f_cpu": "64000000L",
+    "mcu": "stm32g041g6",
+    "variant": "stm32g0"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32G041G6",
+    "openocd_target": "stm32g0x",
+    "svd_path": "STM32G041.svd"
+  },
+  "frameworks": [
+    "stm32cube"
+  ],
+  "name": "STM32G041G6 (8k RAM. 64k Flash)",
+  "upload": {
+    "disable_flushing": false,
+    "maximum_ram_size": 8192,
+    "maximum_size": 65536,
+    "protocol": "stlink",
+    "protocols": [
+      "stlink"
+    ],
+    "require_upload_port": true,
+    "use_1200bps_touch": false,
+    "wait_for_upload_port": false
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32g041g6.html",
+  "vendor": "ST"
+}

--- a/boards/genericSTM32G041G6.json
+++ b/boards/genericSTM32G041G6.json
@@ -25,7 +25,10 @@
     "maximum_size": 65536,
     "protocol": "stlink",
     "protocols": [
-      "stlink"
+      "jlink",
+      "stlink",
+      "blackmagic",
+      "serial"
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,

--- a/boards/genericSTM32G041G8.json
+++ b/boards/genericSTM32G041G8.json
@@ -25,7 +25,10 @@
     "maximum_size": 65536,
     "protocol": "stlink",
     "protocols": [
-      "stlink"
+      "jlink",
+      "stlink",
+      "blackmagic",
+      "serial"
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,

--- a/boards/genericSTM32G041G8.json
+++ b/boards/genericSTM32G041G8.json
@@ -1,0 +1,36 @@
+{
+  "build": {
+    "core": "maple",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DSTM32G0xx -DSTM32G041xx",
+    "f_cpu": "64000000L",
+    "mcu": "stm32g041g8",
+    "variant": "stm32g0"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32G041G8",
+    "openocd_target": "stm32g0x",
+    "svd_path": "STM32G041.svd"
+  },
+  "frameworks": [
+    "stm32cube"
+  ],
+  "name": "STM32G041G8 (8k RAM. 64k Flash)",
+  "upload": {
+    "disable_flushing": false,
+    "maximum_ram_size": 8192,
+    "maximum_size": 65536,
+    "protocol": "stlink",
+    "protocols": [
+      "stlink"
+    ],
+    "require_upload_port": true,
+    "use_1200bps_touch": false,
+    "wait_for_upload_port": false
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32g041g8.html",
+  "vendor": "ST"
+}

--- a/boards/genericSTM32G041J6.json
+++ b/boards/genericSTM32G041J6.json
@@ -25,7 +25,10 @@
     "maximum_size": 32768,
     "protocol": "stlink",
     "protocols": [
-      "stlink"
+      "jlink",
+      "stlink",
+      "blackmagic",
+      "serial"
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,

--- a/boards/genericSTM32G041J6.json
+++ b/boards/genericSTM32G041J6.json
@@ -1,0 +1,36 @@
+{
+  "build": {
+    "core": "maple",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DSTM32G0xx -DSTM32G041xx",
+    "f_cpu": "64000000L",
+    "mcu": "stm32g041j6",
+    "variant": "stm32g0"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32G041J6",
+    "openocd_target": "stm32g0x",
+    "svd_path": "STM32G041.svd"
+  },
+  "frameworks": [
+    "stm32cube"
+  ],
+  "name": "STM32G041J6 (8k RAM. 32k Flash)",
+  "upload": {
+    "disable_flushing": false,
+    "maximum_ram_size": 8192,
+    "maximum_size": 32768,
+    "protocol": "stlink",
+    "protocols": [
+      "stlink"
+    ],
+    "require_upload_port": true,
+    "use_1200bps_touch": false,
+    "wait_for_upload_port": false
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32g041j6.html",
+  "vendor": "ST"
+}

--- a/boards/genericSTM32G041K6.json
+++ b/boards/genericSTM32G041K6.json
@@ -1,0 +1,36 @@
+{
+  "build": {
+    "core": "maple",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DSTM32G0xx -DSTM32G041xx",
+    "f_cpu": "64000000L",
+    "mcu": "stm32g041k6",
+    "variant": "stm32g0"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32G041K6",
+    "openocd_target": "stm32g0x",
+    "svd_path": "STM32G041.svd"
+  },
+  "frameworks": [
+    "stm32cube"
+  ],
+  "name": "STM32G041K6 (8k RAM. 64k Flash)",
+  "upload": {
+    "disable_flushing": false,
+    "maximum_ram_size": 8192,
+    "maximum_size": 65536,
+    "protocol": "stlink",
+    "protocols": [
+      "stlink"
+    ],
+    "require_upload_port": true,
+    "use_1200bps_touch": false,
+    "wait_for_upload_port": false
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32g041k6.html",
+  "vendor": "ST"
+}

--- a/boards/genericSTM32G041K6.json
+++ b/boards/genericSTM32G041K6.json
@@ -25,7 +25,10 @@
     "maximum_size": 65536,
     "protocol": "stlink",
     "protocols": [
-      "stlink"
+      "jlink",
+      "stlink",
+      "blackmagic",
+      "serial"
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,

--- a/boards/genericSTM32G041K8.json
+++ b/boards/genericSTM32G041K8.json
@@ -1,0 +1,36 @@
+{
+  "build": {
+    "core": "maple",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DSTM32G0xx -DSTM32G041xx",
+    "f_cpu": "64000000L",
+    "mcu": "stm32g041k8",
+    "variant": "stm32g0"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32G041K8",
+    "openocd_target": "stm32g0x",
+    "svd_path": "STM32G041.svd"
+  },
+  "frameworks": [
+    "stm32cube"
+  ],
+  "name": "STM32G041K8 (8k RAM. 64k Flash)",
+  "upload": {
+    "disable_flushing": false,
+    "maximum_ram_size": 8192,
+    "maximum_size": 65536,
+    "protocol": "stlink",
+    "protocols": [
+      "stlink"
+    ],
+    "require_upload_port": true,
+    "use_1200bps_touch": false,
+    "wait_for_upload_port": false
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32g041k8.html",
+  "vendor": "ST"
+}

--- a/boards/genericSTM32G041K8.json
+++ b/boards/genericSTM32G041K8.json
@@ -25,7 +25,10 @@
     "maximum_size": 65536,
     "protocol": "stlink",
     "protocols": [
-      "stlink"
+      "jlink",
+      "stlink",
+      "blackmagic",
+      "serial"
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,

--- a/boards/genericSTM32G041Y8.json
+++ b/boards/genericSTM32G041Y8.json
@@ -1,0 +1,36 @@
+{
+  "build": {
+    "core": "maple",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DSTM32G0xx -DSTM32G041xx",
+    "f_cpu": "64000000L",
+    "mcu": "stm32g041y8",
+    "variant": "stm32g0"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32G041Y8",
+    "openocd_target": "stm32g0x",
+    "svd_path": "STM32G041.svd"
+  },
+  "frameworks": [
+    "stm32cube"
+  ],
+  "name": "STM32G041Y8 (8k RAM. 64k Flash)",
+  "upload": {
+    "disable_flushing": false,
+    "maximum_ram_size": 8192,
+    "maximum_size": 65536,
+    "protocol": "stlink",
+    "protocols": [
+      "stlink"
+    ],
+    "require_upload_port": true,
+    "use_1200bps_touch": false,
+    "wait_for_upload_port": false
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32g041y8.html",
+  "vendor": "ST"
+}

--- a/boards/genericSTM32G041Y8.json
+++ b/boards/genericSTM32G041Y8.json
@@ -25,7 +25,10 @@
     "maximum_size": 65536,
     "protocol": "stlink",
     "protocols": [
-      "stlink"
+      "jlink",
+      "stlink",
+      "blackmagic",
+      "serial"
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,

--- a/boards/genericSTM32G070CB.json
+++ b/boards/genericSTM32G070CB.json
@@ -25,7 +25,10 @@
     "maximum_size": 131072,
     "protocol": "stlink",
     "protocols": [
-      "stlink"
+      "jlink",
+      "stlink",
+      "blackmagic",
+      "serial"
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,

--- a/boards/genericSTM32G070CB.json
+++ b/boards/genericSTM32G070CB.json
@@ -1,0 +1,36 @@
+{
+  "build": {
+    "core": "maple",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DSTM32G0xx -DSTM32G070xx",
+    "f_cpu": "64000000L",
+    "mcu": "stm32g070cb",
+    "variant": "stm32g0"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32G070CB",
+    "openocd_target": "stm32g0x",
+    "svd_path": "STM32G070.svd"
+  },
+  "frameworks": [
+    "stm32cube"
+  ],
+  "name": "STM32G070CB (36k RAM. 128k Flash)",
+  "upload": {
+    "disable_flushing": false,
+    "maximum_ram_size": 36864,
+    "maximum_size": 131072,
+    "protocol": "stlink",
+    "protocols": [
+      "stlink"
+    ],
+    "require_upload_port": true,
+    "use_1200bps_touch": false,
+    "wait_for_upload_port": false
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32g070cb.html",
+  "vendor": "ST"
+}

--- a/boards/genericSTM32G070KB.json
+++ b/boards/genericSTM32G070KB.json
@@ -25,7 +25,10 @@
     "maximum_size": 131072,
     "protocol": "stlink",
     "protocols": [
-      "stlink"
+      "jlink",
+      "stlink",
+      "blackmagic",
+      "serial"
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,

--- a/boards/genericSTM32G070KB.json
+++ b/boards/genericSTM32G070KB.json
@@ -1,0 +1,36 @@
+{
+  "build": {
+    "core": "maple",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DSTM32G0xx -DSTM32G070xx",
+    "f_cpu": "64000000L",
+    "mcu": "stm32g070kb",
+    "variant": "stm32g0"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32G070KB",
+    "openocd_target": "stm32g0x",
+    "svd_path": "STM32G070.svd"
+  },
+  "frameworks": [
+    "stm32cube"
+  ],
+  "name": "STM32G070KB (36k RAM. 128k Flash)",
+  "upload": {
+    "disable_flushing": false,
+    "maximum_ram_size": 36864,
+    "maximum_size": 131072,
+    "protocol": "stlink",
+    "protocols": [
+      "stlink"
+    ],
+    "require_upload_port": true,
+    "use_1200bps_touch": false,
+    "wait_for_upload_port": false
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32g070kb.html",
+  "vendor": "ST"
+}

--- a/boards/genericSTM32G070RB.json
+++ b/boards/genericSTM32G070RB.json
@@ -1,0 +1,36 @@
+{
+  "build": {
+    "core": "maple",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DSTM32G0xx -DSTM32G070xx",
+    "f_cpu": "64000000L",
+    "mcu": "stm32g070rb",
+    "variant": "stm32g0"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32G070RB",
+    "openocd_target": "stm32g0x",
+    "svd_path": "STM32G070.svd"
+  },
+  "frameworks": [
+    "stm32cube"
+  ],
+  "name": "STM32G070RB (36k RAM. 128k Flash)",
+  "upload": {
+    "disable_flushing": false,
+    "maximum_ram_size": 36864,
+    "maximum_size": 131072,
+    "protocol": "stlink",
+    "protocols": [
+      "stlink"
+    ],
+    "require_upload_port": true,
+    "use_1200bps_touch": false,
+    "wait_for_upload_port": false
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32g070rb.html",
+  "vendor": "ST"
+}

--- a/boards/genericSTM32G070RB.json
+++ b/boards/genericSTM32G070RB.json
@@ -25,7 +25,10 @@
     "maximum_size": 131072,
     "protocol": "stlink",
     "protocols": [
-      "stlink"
+      "jlink",
+      "stlink",
+      "blackmagic",
+      "serial"
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,

--- a/boards/genericSTM32G071C8.json
+++ b/boards/genericSTM32G071C8.json
@@ -25,7 +25,10 @@
     "maximum_size": 65536,
     "protocol": "stlink",
     "protocols": [
-      "stlink"
+      "jlink",
+      "stlink",
+      "blackmagic",
+      "serial"
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,

--- a/boards/genericSTM32G071C8.json
+++ b/boards/genericSTM32G071C8.json
@@ -1,0 +1,36 @@
+{
+  "build": {
+    "core": "maple",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DSTM32G0xx -DSTM32G071xx",
+    "f_cpu": "64000000L",
+    "mcu": "stm32g071c8",
+    "variant": "stm32g0"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32G071C8",
+    "openocd_target": "stm32g0x",
+    "svd_path": "STM32G071.svd"
+  },
+  "frameworks": [
+    "stm32cube"
+  ],
+  "name": "STM32G071C8 (36k RAM. 64k Flash)",
+  "upload": {
+    "disable_flushing": false,
+    "maximum_ram_size": 36864,
+    "maximum_size": 65536,
+    "protocol": "stlink",
+    "protocols": [
+      "stlink"
+    ],
+    "require_upload_port": true,
+    "use_1200bps_touch": false,
+    "wait_for_upload_port": false
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32g071c8.html",
+  "vendor": "ST"
+}

--- a/boards/genericSTM32G071CB.json
+++ b/boards/genericSTM32G071CB.json
@@ -1,0 +1,42 @@
+{
+  "build": {
+    "core": "maple",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DSTM32G0xx -DSTM32G071xx",
+    "f_cpu": "64000000L",
+    "mcu": "stm32g071cb",
+    "variant": "stm32g0"
+  },
+  "asdfdebug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32FG071CB",
+    "openocd_extra_args": [
+            "-c",
+            "reset_config none"
+          ],
+    "openocd_target": "stm32g0x",
+    "svd_path": "STM32G0x.svd"
+  },
+  "frameworks": [
+    "stm32cube"
+  ],
+  "name": "STM32G071CB (36k RAM. 128k Flash)",
+  "upload": {
+    "disable_flushing": false,
+    "maximum_ram_size": 36864,
+    "maximum_size": 131072,
+    "protocol": "stlink",
+    "protocols": [
+      "stlink",
+      "dfu",
+      "jlink"
+    ],
+    "require_upload_port": true,
+    "use_1200bps_touch": false,
+    "wait_for_upload_port": false
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32g071cb.html",
+  "vendor": "Generic"
+}

--- a/boards/genericSTM32G071CB.json
+++ b/boards/genericSTM32G071CB.json
@@ -25,7 +25,10 @@
     "maximum_size": 131072,
     "protocol": "stlink",
     "protocols": [
-      "stlink"
+      "jlink",
+      "stlink",
+      "blackmagic",
+      "serial"
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,

--- a/boards/genericSTM32G071CB.json
+++ b/boards/genericSTM32G071CB.json
@@ -12,10 +12,6 @@
       "stlink"
     ],
     "jlink_device": "STM32FG071CB",
-    "openocd_extra_args": [
-            "-c",
-            "reset_config none"
-          ],
     "openocd_target": "stm32g0x",
     "svd_path": "STM32G0x.svd"
   },

--- a/boards/genericSTM32G071CB.json
+++ b/boards/genericSTM32G071CB.json
@@ -7,7 +7,7 @@
     "mcu": "stm32g071cb",
     "variant": "stm32g0"
   },
-  "asdfdebug": {
+  "debug": {
     "default_tools": [
       "stlink"
     ],
@@ -29,9 +29,7 @@
     "maximum_size": 131072,
     "protocol": "stlink",
     "protocols": [
-      "stlink",
-      "dfu",
-      "jlink"
+      "stlink"
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,

--- a/boards/genericSTM32G071CB.json
+++ b/boards/genericSTM32G071CB.json
@@ -11,9 +11,9 @@
     "default_tools": [
       "stlink"
     ],
-    "jlink_device": "STM32FG071CB",
+    "jlink_device": "STM32G071CB",
     "openocd_target": "stm32g0x",
-    "svd_path": "STM32G0x.svd"
+    "svd_path": "STM32G071.svd"
   },
   "frameworks": [
     "stm32cube"
@@ -32,5 +32,5 @@
     "wait_for_upload_port": false
   },
   "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32g071cb.html",
-  "vendor": "Generic"
+  "vendor": "ST"
 }

--- a/boards/genericSTM32G071EB.json
+++ b/boards/genericSTM32G071EB.json
@@ -25,7 +25,10 @@
     "maximum_size": 131072,
     "protocol": "stlink",
     "protocols": [
-      "stlink"
+      "jlink",
+      "stlink",
+      "blackmagic",
+      "serial"
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,

--- a/boards/genericSTM32G071EB.json
+++ b/boards/genericSTM32G071EB.json
@@ -1,0 +1,36 @@
+{
+  "build": {
+    "core": "maple",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DSTM32G0xx -DSTM32G071xx",
+    "f_cpu": "64000000L",
+    "mcu": "stm32g071eb",
+    "variant": "stm32g0"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32G071EB",
+    "openocd_target": "stm32g0x",
+    "svd_path": "STM32G071.svd"
+  },
+  "frameworks": [
+    "stm32cube"
+  ],
+  "name": "STM32G071EB (36k RAM. 128k Flash)",
+  "upload": {
+    "disable_flushing": false,
+    "maximum_ram_size": 36864,
+    "maximum_size": 131072,
+    "protocol": "stlink",
+    "protocols": [
+      "stlink"
+    ],
+    "require_upload_port": true,
+    "use_1200bps_touch": false,
+    "wait_for_upload_port": false
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32g071eb.html",
+  "vendor": "ST"
+}

--- a/boards/genericSTM32G071G8.json
+++ b/boards/genericSTM32G071G8.json
@@ -25,7 +25,10 @@
     "maximum_size": 131072,
     "protocol": "stlink",
     "protocols": [
-      "stlink"
+      "jlink",
+      "stlink",
+      "blackmagic",
+      "serial"
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,

--- a/boards/genericSTM32G071G8.json
+++ b/boards/genericSTM32G071G8.json
@@ -1,0 +1,36 @@
+{
+  "build": {
+    "core": "maple",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DSTM32G0xx -DSTM32G071xx",
+    "f_cpu": "64000000L",
+    "mcu": "stm32g071g8",
+    "variant": "stm32g0"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32G071G8",
+    "openocd_target": "stm32g0x",
+    "svd_path": "STM32G071.svd"
+  },
+  "frameworks": [
+    "stm32cube"
+  ],
+  "name": "STM32G071G8 (36k RAM. 128k Flash)",
+  "upload": {
+    "disable_flushing": false,
+    "maximum_ram_size": 36864,
+    "maximum_size": 131072,
+    "protocol": "stlink",
+    "protocols": [
+      "stlink"
+    ],
+    "require_upload_port": true,
+    "use_1200bps_touch": false,
+    "wait_for_upload_port": false
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32g071g8.html",
+  "vendor": "ST"
+}

--- a/boards/genericSTM32G071GB.json
+++ b/boards/genericSTM32G071GB.json
@@ -25,7 +25,10 @@
     "maximum_size": 131072,
     "protocol": "stlink",
     "protocols": [
-      "stlink"
+      "jlink",
+      "stlink",
+      "blackmagic",
+      "serial"
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,

--- a/boards/genericSTM32G071GB.json
+++ b/boards/genericSTM32G071GB.json
@@ -1,0 +1,36 @@
+{
+  "build": {
+    "core": "maple",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DSTM32G0xx -DSTM32G071xx",
+    "f_cpu": "64000000L",
+    "mcu": "stm32g071gb",
+    "variant": "stm32g0"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32G071GB",
+    "openocd_target": "stm32g0x",
+    "svd_path": "STM32G071.svd"
+  },
+  "frameworks": [
+    "stm32cube"
+  ],
+  "name": "STM32G071GB (36k RAM. 128k Flash)",
+  "upload": {
+    "disable_flushing": false,
+    "maximum_ram_size": 36864,
+    "maximum_size": 131072,
+    "protocol": "stlink",
+    "protocols": [
+      "stlink"
+    ],
+    "require_upload_port": true,
+    "use_1200bps_touch": false,
+    "wait_for_upload_port": false
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32g071gb.html",
+  "vendor": "ST"
+}

--- a/boards/genericSTM32G071K8.json
+++ b/boards/genericSTM32G071K8.json
@@ -1,0 +1,36 @@
+{
+  "build": {
+    "core": "maple",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DSTM32G0xx -DSTM32G071xx",
+    "f_cpu": "64000000L",
+    "mcu": "stm32g071k8",
+    "variant": "stm32g0"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32G071K8",
+    "openocd_target": "stm32g0x",
+    "svd_path": "STM32G071.svd"
+  },
+  "frameworks": [
+    "stm32cube"
+  ],
+  "name": "STM32G071K8 (36k RAM. 64k Flash)",
+  "upload": {
+    "disable_flushing": false,
+    "maximum_ram_size": 36864,
+    "maximum_size": 65536,
+    "protocol": "stlink",
+    "protocols": [
+      "stlink"
+    ],
+    "require_upload_port": true,
+    "use_1200bps_touch": false,
+    "wait_for_upload_port": false
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32g071k8.html",
+  "vendor": "ST"
+}

--- a/boards/genericSTM32G071K8.json
+++ b/boards/genericSTM32G071K8.json
@@ -25,7 +25,10 @@
     "maximum_size": 65536,
     "protocol": "stlink",
     "protocols": [
-      "stlink"
+      "jlink",
+      "stlink",
+      "blackmagic",
+      "serial"
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,

--- a/boards/genericSTM32G071KB.json
+++ b/boards/genericSTM32G071KB.json
@@ -25,7 +25,10 @@
     "maximum_size": 131072,
     "protocol": "stlink",
     "protocols": [
-      "stlink"
+      "jlink",
+      "stlink",
+      "blackmagic",
+      "serial"
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,

--- a/boards/genericSTM32G071KB.json
+++ b/boards/genericSTM32G071KB.json
@@ -1,0 +1,36 @@
+{
+  "build": {
+    "core": "maple",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DSTM32G0xx -DSTM32G071xx",
+    "f_cpu": "64000000L",
+    "mcu": "stm32g071kb",
+    "variant": "stm32g0"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32G071KB",
+    "openocd_target": "stm32g0x",
+    "svd_path": "STM32G071.svd"
+  },
+  "frameworks": [
+    "stm32cube"
+  ],
+  "name": "STM32G071KB (36k RAM. 128k Flash)",
+  "upload": {
+    "disable_flushing": false,
+    "maximum_ram_size": 36864,
+    "maximum_size": 131072,
+    "protocol": "stlink",
+    "protocols": [
+      "stlink"
+    ],
+    "require_upload_port": true,
+    "use_1200bps_touch": false,
+    "wait_for_upload_port": false
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32g071kb.html",
+  "vendor": "ST"
+}

--- a/boards/genericSTM32G071R8.json
+++ b/boards/genericSTM32G071R8.json
@@ -1,0 +1,36 @@
+{
+  "build": {
+    "core": "maple",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DSTM32G0xx -DSTM32G071xx",
+    "f_cpu": "64000000L",
+    "mcu": "stm32g071r8",
+    "variant": "stm32g0"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32G071R8",
+    "openocd_target": "stm32g0x",
+    "svd_path": "STM32G071.svd"
+  },
+  "frameworks": [
+    "stm32cube"
+  ],
+  "name": "STM32G071R8 (36k RAM. 64k Flash)",
+  "upload": {
+    "disable_flushing": false,
+    "maximum_ram_size": 36864,
+    "maximum_size": 65536,
+    "protocol": "stlink",
+    "protocols": [
+      "stlink"
+    ],
+    "require_upload_port": true,
+    "use_1200bps_touch": false,
+    "wait_for_upload_port": false
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32g071r8.html",
+  "vendor": "ST"
+}

--- a/boards/genericSTM32G071R8.json
+++ b/boards/genericSTM32G071R8.json
@@ -25,7 +25,10 @@
     "maximum_size": 65536,
     "protocol": "stlink",
     "protocols": [
-      "stlink"
+      "jlink",
+      "stlink",
+      "blackmagic",
+      "serial"
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,

--- a/boards/genericSTM32G071RB.json
+++ b/boards/genericSTM32G071RB.json
@@ -25,7 +25,10 @@
     "maximum_size": 131072,
     "protocol": "stlink",
     "protocols": [
-      "stlink"
+      "jlink",
+      "stlink",
+      "blackmagic",
+      "serial"
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,

--- a/boards/genericSTM32G071RB.json
+++ b/boards/genericSTM32G071RB.json
@@ -1,0 +1,36 @@
+{
+  "build": {
+    "core": "maple",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DSTM32G0xx -DSTM32G071xx",
+    "f_cpu": "64000000L",
+    "mcu": "stm32g071rb",
+    "variant": "stm32g0"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32G071RB",
+    "openocd_target": "stm32g0x",
+    "svd_path": "STM32G071.svd"
+  },
+  "frameworks": [
+    "stm32cube"
+  ],
+  "name": "STM32G071RB (36k RAM. 128k Flash)",
+  "upload": {
+    "disable_flushing": false,
+    "maximum_ram_size": 36864,
+    "maximum_size": 131072,
+    "protocol": "stlink",
+    "protocols": [
+      "stlink"
+    ],
+    "require_upload_port": true,
+    "use_1200bps_touch": false,
+    "wait_for_upload_port": false
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32g071rb.html",
+  "vendor": "ST"
+}

--- a/boards/genericSTM32G081CB.json
+++ b/boards/genericSTM32G081CB.json
@@ -1,0 +1,36 @@
+{
+  "build": {
+    "core": "maple",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DSTM32G0xx -DSTM32G081xx",
+    "f_cpu": "64000000L",
+    "mcu": "stm32g081cb",
+    "variant": "stm32g0"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32G081CB",
+    "openocd_target": "stm32g0x",
+    "svd_path": "STM32G081.svd"
+  },
+  "frameworks": [
+    "stm32cube"
+  ],
+  "name": "STM32G081CB (36k RAM. 128k Flash)",
+  "upload": {
+    "disable_flushing": false,
+    "maximum_ram_size": 36864,
+    "maximum_size": 131072,
+    "protocol": "stlink",
+    "protocols": [
+      "stlink"
+    ],
+    "require_upload_port": true,
+    "use_1200bps_touch": false,
+    "wait_for_upload_port": false
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32g081cb.html",
+  "vendor": "ST"
+}

--- a/boards/genericSTM32G081CB.json
+++ b/boards/genericSTM32G081CB.json
@@ -25,7 +25,10 @@
     "maximum_size": 131072,
     "protocol": "stlink",
     "protocols": [
-      "stlink"
+      "jlink",
+      "stlink",
+      "blackmagic",
+      "serial"
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,

--- a/boards/genericSTM32G081EB.json
+++ b/boards/genericSTM32G081EB.json
@@ -25,7 +25,10 @@
     "maximum_size": 131072,
     "protocol": "stlink",
     "protocols": [
-      "stlink"
+      "jlink",
+      "stlink",
+      "blackmagic",
+      "serial"
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,

--- a/boards/genericSTM32G081EB.json
+++ b/boards/genericSTM32G081EB.json
@@ -1,0 +1,36 @@
+{
+  "build": {
+    "core": "maple",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DSTM32G0xx -DSTM32G081xx",
+    "f_cpu": "64000000L",
+    "mcu": "stm32g081eb",
+    "variant": "stm32g0"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32G081EB",
+    "openocd_target": "stm32g0x",
+    "svd_path": "STM32G081.svd"
+  },
+  "frameworks": [
+    "stm32cube"
+  ],
+  "name": "STM32G081EB (36k RAM. 128k Flash)",
+  "upload": {
+    "disable_flushing": false,
+    "maximum_ram_size": 36864,
+    "maximum_size": 131072,
+    "protocol": "stlink",
+    "protocols": [
+      "stlink"
+    ],
+    "require_upload_port": true,
+    "use_1200bps_touch": false,
+    "wait_for_upload_port": false
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32g081eb.html",
+  "vendor": "ST"
+}

--- a/boards/genericSTM32G081GB.json
+++ b/boards/genericSTM32G081GB.json
@@ -25,7 +25,10 @@
     "maximum_size": 131072,
     "protocol": "stlink",
     "protocols": [
-      "stlink"
+      "jlink",
+      "stlink",
+      "blackmagic",
+      "serial"
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,

--- a/boards/genericSTM32G081GB.json
+++ b/boards/genericSTM32G081GB.json
@@ -1,0 +1,36 @@
+{
+  "build": {
+    "core": "maple",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DSTM32G0xx -DSTM32G081xx",
+    "f_cpu": "64000000L",
+    "mcu": "stm32g081gb",
+    "variant": "stm32g0"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32G081GB",
+    "openocd_target": "stm32g0x",
+    "svd_path": "STM32G081.svd"
+  },
+  "frameworks": [
+    "stm32cube"
+  ],
+  "name": "STM32G081GB (36k RAM. 128k Flash)",
+  "upload": {
+    "disable_flushing": false,
+    "maximum_ram_size": 36864,
+    "maximum_size": 131072,
+    "protocol": "stlink",
+    "protocols": [
+      "stlink"
+    ],
+    "require_upload_port": true,
+    "use_1200bps_touch": false,
+    "wait_for_upload_port": false
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32g081gb.html",
+  "vendor": "ST"
+}

--- a/boards/genericSTM32G081KB.json
+++ b/boards/genericSTM32G081KB.json
@@ -25,7 +25,10 @@
     "maximum_size": 131072,
     "protocol": "stlink",
     "protocols": [
-      "stlink"
+      "jlink",
+      "stlink",
+      "blackmagic",
+      "serial"
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,

--- a/boards/genericSTM32G081KB.json
+++ b/boards/genericSTM32G081KB.json
@@ -1,0 +1,36 @@
+{
+  "build": {
+    "core": "maple",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DSTM32G0xx -DSTM32G081xx",
+    "f_cpu": "64000000L",
+    "mcu": "stm32g081kb",
+    "variant": "stm32g0"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32G081KB",
+    "openocd_target": "stm32g0x",
+    "svd_path": "STM32G081.svd"
+  },
+  "frameworks": [
+    "stm32cube"
+  ],
+  "name": "STM32G081KB (36k RAM. 128k Flash)",
+  "upload": {
+    "disable_flushing": false,
+    "maximum_ram_size": 36864,
+    "maximum_size": 131072,
+    "protocol": "stlink",
+    "protocols": [
+      "stlink"
+    ],
+    "require_upload_port": true,
+    "use_1200bps_touch": false,
+    "wait_for_upload_port": false
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32g081kb.html",
+  "vendor": "ST"
+}

--- a/boards/genericSTM32G081RB.json
+++ b/boards/genericSTM32G081RB.json
@@ -25,7 +25,10 @@
     "maximum_size": 131072,
     "protocol": "stlink",
     "protocols": [
-      "stlink"
+      "jlink",
+      "stlink",
+      "blackmagic",
+      "serial"
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,

--- a/boards/genericSTM32G081RB.json
+++ b/boards/genericSTM32G081RB.json
@@ -1,0 +1,36 @@
+{
+  "build": {
+    "core": "maple",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DSTM32G0xx -DSTM32G081xx",
+    "f_cpu": "64000000L",
+    "mcu": "stm32g081rb",
+    "variant": "stm32g0"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32G081RB",
+    "openocd_target": "stm32g0x",
+    "svd_path": "STM32G081.svd"
+  },
+  "frameworks": [
+    "stm32cube"
+  ],
+  "name": "STM32G081RB (36k RAM. 128k Flash)",
+  "upload": {
+    "disable_flushing": false,
+    "maximum_ram_size": 36864,
+    "maximum_size": 131072,
+    "protocol": "stlink",
+    "protocols": [
+      "stlink"
+    ],
+    "require_upload_port": true,
+    "use_1200bps_touch": false,
+    "wait_for_upload_port": false
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32g081rb.html",
+  "vendor": "ST"
+}

--- a/platform.json
+++ b/platform.json
@@ -12,7 +12,7 @@
     "type": "git",
     "url": "https://github.com/platformio/platform-ststm32.git"
   },
-  "version": "6.1.0",
+  "version": "6.2.0",
   "packageRepositories": [
     "https://dl.bintray.com/platformio/dl-packages/manifest.json",
     "http://dl.platformio.org/packages/manifest.json"
@@ -90,7 +90,7 @@
     "framework-stm32cube": {
       "type": "framework",
       "optional": true,
-      "version": "~2.0.181130"
+      "version": "~2.1.0-alpha"
     },
     "framework-zephyr": {
       "type": "framework",

--- a/platform.json
+++ b/platform.json
@@ -173,7 +173,7 @@
     "tool-openocd": {
       "type": "uploader",
       "optional": true,
-      "version": "~2.1000.0"
+      "version": "~2.1014.200515"
     },
     "tool-jlink": {
       "type": "uploader",


### PR DESCRIPTION
This pull request adds initial support for STM32G0 devices, using stm32cube libraries.

It contains board files for all G0 MCUs and they link up to the existing svd files.
STM32G0 devices have their own version of stm32cube libraries, which have to be added to
the `framework-stm32cube` package.

Unfortunately, that package does not have a git repository. But @JcBernack created one, so i forked it and added the required libraries: [framework-stm32cube](https://github.com/functionpointer/framework-stm32cube)

Finally, we need a new version of openocd. Turns out [xPack](https://github.com/xpack-dev-tools/) has built binaries with a new enough version of openocd, so i packed that into a ready-to use bundle as well: [tool-openocd](https://github.com/functionpointer/tool-openocd)
I have only bundled the windows version for now.

If anyone wants to try it, use the following as your `platformio.ini`
```
[env:stm32g0]
platform = https://github.com/functionpointer/platform-ststm32
framework = stm32cube
board = genericSTM32G071CB

platform_packages =
  framework-stm32cube @ https://github.com/functionpointer/framework-stm32cube
  tool-openocd @ https://github.com/functionpointer/tool-openocd/releases/latest/download/tool-openocd.tar.gz
```

I have personally tested the STM32G071CB. All other MCUs are untested.

MCUs other than STM32G071CB are missing [startup files](https://github.com/functionpointer/framework-stm32cube/tree/master/platformio/ldscripts), but maybe the template will work? Otherwise they can be generated with STM32CubeMX.