### PR TITLE
Treat CMSIS and HAL includes as system ones

### DIFF
--- a/builder/frameworks/cmsis.py
+++ b/builder/frameworks/cmsis.py
@@ -110,10 +110,13 @@ def get_linker_script(mcu):
 
     return default_ldscript
 
-env.Append(CPPPATH=[
+env.Append(CPPFLAGS=[
+    "-isystem",
     join(FRAMEWORK_DIR, "CMSIS", "Core", "Include"),
+    "-isystem",
     join(FRAMEWORK_DIR, "variants", PLATFORM_NAME,
          board.get("build.mcu")[0:7], "common"),
+    "-isystem",
     join(FRAMEWORK_DIR, "variants", board.get("build.mcu")[0:7],
          board.get("build.mcu"))
 ])

--- a/builder/frameworks/stm32cube.py
+++ b/builder/frameworks/stm32cube.py
@@ -207,13 +207,16 @@ elif "F103x8" in cpp_flags:
 
 
 env.Append(
-    CPPPATH=[
+    CPPFLAGS=[
+        "-isystem",
         join(FRAMEWORK_DIR, FRAMEWORK_CORE, "Drivers", "CMSIS", "Include"),
+        "-isystem",
         join(FRAMEWORK_DIR, FRAMEWORK_CORE, "Drivers", "CMSIS", "Device",
              "ST", MCU_FAMILY.upper() + "xx", "Include"),
-
+        "-isystem",
         join(FRAMEWORK_DIR, FRAMEWORK_CORE, "Drivers",
              MCU_FAMILY.upper() + "xx_HAL_Driver", "Inc"),
+        "-isystem",
         join(FRAMEWORK_DIR, FRAMEWORK_CORE, "Drivers",
              "BSP", "Components", "Common")
     ],


### PR DESCRIPTION
The keyword `register` is deprecated in C++17. CMSIS and HAL libraries use it a lot in their headers. Therefore, when compiling a project with C++17 flags, the user gets a lot of irrelevant warnings during compilation like:
```
warning: ISO C++1z does not allow 'register' storage class specifier [-Wregister]
```

It makes the compiler output practically unusable.

I think the CMSIS and HAL includes should be treated as a system includes - one of the effects is that compiler does not show warnings from these headers as the user cannot change anything about it.

This PR changes that. There is no direct way of specifying it in SCons ([according to StackOverflow](https://stackoverflow.com/questions/2441047/how-do-i-set-scons-system-include-path/2547261)), therefore it has to be done directly via CPPFLAGS. It should cause no harm, as GCC is always used as the compiler in this case.