### PR TITLE
Fix for issue #386 to enable LTO support.

### DIFF
--- a/builder/main.py
+++ b/builder/main.py
@@ -27,13 +27,13 @@ platform = env.PioPlatform()
 board = env.BoardConfig()
 
 env.Replace(
-    AR="arm-none-eabi-ar",
+    AR="arm-none-eabi-gcc-ar",
     AS="arm-none-eabi-as",
     CC="arm-none-eabi-gcc",
     CXX="arm-none-eabi-g++",
     GDB="arm-none-eabi-gdb",
     OBJCOPY="arm-none-eabi-objcopy",
-    RANLIB="arm-none-eabi-ranlib",
+    RANLIB="arm-none-eabi-gcc-ranlib",
     SIZETOOL="arm-none-eabi-size",
 
     ARFLAGS=["rc"],


### PR DESCRIPTION
This pull request adds support for the gcc/g++ `-flto` flag by using the plugin enabled versions of `ar` and `ranlib`. This does not include the `-flto` flag by default. toolchain-gccarmnoneeabi 1.70201.0 seems to fail at linking stage when using LTO in some cases. A newer toolchain like 1.90201.191206 should be used instead when compiling with LTO.