### PR TITLE
Add board: blackpill_f401ce

### DIFF
--- a/boards/blackpill_f401cc.json
+++ b/boards/blackpill_f401cc.json
@@ -4,7 +4,7 @@
     "cpu": "cortex-m4",
     "extra_flags": "-DSTM32F4xx -DSTM32F401xC",
     "f_cpu": "84000000L",
-    "mcu": "stm32f401cct6",
+    "mcu": "stm32f401ccu6",
     "product_line": "STM32F401xC",
     "variant": "Generic_F401Cx"
   },

--- a/boards/blackpill_f401ce.json
+++ b/boards/blackpill_f401ce.json
@@ -1,0 +1,40 @@
+{
+  "build": {
+    "core": "stm32",
+    "cpu": "cortex-m4",
+    "extra_flags": "-DSTM32F4xx -DSTM32F401xE",
+    "f_cpu": "84000000L",
+    "mcu": "stm32f401ceu6",
+    "product_line": "STM32F401xE",
+    "variant": "Generic_F401Cx"
+  },
+  "connectivity": [
+    "can"
+  ],
+  "debug": {
+    "jlink_device": "STM32F401CE",
+    "openocd_target": "stm32f4x",
+    "svd_path": "STM32F40x.svd"
+  },
+  "frameworks": [
+    "arduino",
+    "cmsis",
+    "stm32cube",
+    "libopencm3"
+  ],
+  "name": "BlackPill F401CE",
+  "upload": {
+    "maximum_ram_size": 98304,
+    "maximum_size": 524288,
+    "protocol": "stlink",
+    "protocols": [
+      "jlink",
+      "stlink",
+      "blackmagic",
+      "serial",
+      "dfu"
+    ]
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32f401ce.html",
+  "vendor": "ST"
+}


### PR DESCRIPTION
WeAct actually stopped producing the F401C**C** black pill, they have replaced it with a slightly upgraded version, based on an F401C**E** processor (not to be confused with the existing board definition for the F4**1**1CE version of the board) The board is the same except for upgraded RAM (96KB) and flash (512KB). I didn't actually test this out, but it was a simple change - I just changed all references of F401CC to F401CE and updated the flash and ram sizes.

Let me know if something's missing here, it's my first PR to this project!