### PR TITLE
adding disco b_g431b_esc1 board variant

### DIFF
--- a/boards/disco_b_g431b_esc1.json
+++ b/boards/disco_b_g431b_esc1.json
@@ -1,0 +1,45 @@
+{
+  "build": {
+    "core": "stm32",
+    "cpu": "cortex-m4",
+    "extra_flags": "-DSTM32G4xx -DSTM32G431xx -DSTM32G431CBU",
+    "f_cpu": "170000000L",
+    "mcu": "stm32g431cbu6",
+    "product_line": "STM32G431xx",
+    "variant": "DISCO_B_G431B_ESC1"
+  },
+  "connectivity": [
+    "can"
+  ],
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32G431CB",
+    "onboard_tools": [
+      "stlink"
+    ],
+    "openocd_board": "stm32g4discovery",
+    "svd_path": "STM32G431xx.svd"
+  },
+  "frameworks": [
+    "arduino",
+    "cmsis",
+    "libopencm3",
+    "zephyr"
+  ],
+  "name": "B-G431B-ESC1 Discovery",
+  "upload": {
+    "maximum_ram_size": 32768,
+    "maximum_size": 131072,
+    "protocol": "mbed",
+    "protocols": [
+      "jlink",
+      "blackmagic",
+      "stlink",
+      "mbed"
+    ]
+  },
+  "url": "https://www.st.com/en/evaluation-tools/b-g431b-esc1.html",
+  "vendor": "ST"
+}

--- a/boards/disco_b_g431b_esc1.json
+++ b/boards/disco_b_g431b_esc1.json
@@ -1,12 +1,17 @@
+disco_b_g431b_esc1
+
 {
   "build": {
     "core": "stm32",
     "cpu": "cortex-m4",
-    "extra_flags": "-DSTM32G4xx -DSTM32G431xx -DSTM32G431CBU",
+    "extra_flags": "-DSTM32G4xx -DSTM32G431xx",
     "f_cpu": "170000000L",
+    "framework_extra_flags": {
+      "arduino": "-DCUSTOM_PERIPHERAL_PINS"
+    },
     "mcu": "stm32g431cbu6",
     "product_line": "STM32G431xx",
-    "variant": "DISCO_B_G431B_ESC1"
+    "variant": "STM32G4xx/G431C(6-8-B)U_G441CBU"
   },
   "connectivity": [
     "can"
@@ -19,24 +24,24 @@
     "onboard_tools": [
       "stlink"
     ],
-    "openocd_board": "stm32g4discovery",
+    "openocd_target": "stm32g4x",
     "svd_path": "STM32G431xx.svd"
   },
   "frameworks": [
     "arduino",
     "cmsis",
-    "libopencm3",
-    "zephyr"
+    "stm32cube"
   ],
-  "name": "B-G431B-ESC1 Discovery",
+  "name": "ST B-G431B-ESC1 Discovery",
   "upload": {
     "maximum_ram_size": 32768,
     "maximum_size": 131072,
-    "protocol": "mbed",
+    "protocol": "stlink",
     "protocols": [
-      "jlink",
-      "blackmagic",
       "stlink",
+      "jlink",
+      "cmsis-dap",
+      "blackmagic",
       "mbed"
     ]
   },


### PR DESCRIPTION
This pull request relates to, and is blocked by, a PR to add support for new stm32g4 board variant `b_g431b_esc1`:
https://github.com/stm32duino/Arduino_Core_STM32/pull/1236

Also note that I'm in the process of trying to get stm32g4 openocd debugging simpler to use in platformio by adding a g4 target to openocd.  The json below references this not-yet-merged `openocd_board` .  OpenOCD PR here:
https://sourceforge.net/p/openocd/code/merge-requests/16/

