### PR TITLE
Fix STM32F407VG Ram Size

### DIFF
--- a/boards/genericSTM32F407VGT6.json
+++ b/boards/genericSTM32F407VGT6.json
@@ -39,7 +39,7 @@
   "name": "STM32F407VG (192k RAM. 1024k Flash)",
   "upload": {
     "disable_flushing": false,
-    "maximum_ram_size": 196608,
+    "maximum_ram_size": 131072,
     "maximum_size": 1048576,
     "protocol": "stlink",
     "protocols": [

--- a/boards/genericSTM32F407VGT6.json
+++ b/boards/genericSTM32F407VGT6.json
@@ -36,7 +36,7 @@
     "stm32cube",
     "libopencm3"
   ],
-  "name": "STM32F407VG (192k RAM. 1024k Flash)",
+  "name": "STM32F407VG (128k RAM. 1024k Flash)",
   "upload": {
     "disable_flushing": false,
     "maximum_ram_size": 131072,


### PR DESCRIPTION
This board have 192kb of ram, but 64kb are CCM at 0x10000000. The normal ram at 0x20000000 is 128kb, exactly as STM32F407VE.

The main change from E to G is the flash size. The ram is the same.

<img width="851" alt="Screen Shot 2020-12-09 at 00 37 14" src="https://user-images.githubusercontent.com/81722/101920205-4bf8ae80-3baa-11eb-9336-73afa4b6020f.png">
