### PR TITLE
Fix product_line and variant

### DIFF
--- a/boards/nucleo_g431kb.json
+++ b/boards/nucleo_g431kb.json
@@ -5,8 +5,8 @@
     "extra_flags": "-DSTM32G4xx -DSTM32G431xx",
     "f_cpu": "170000000L",
     "mcu": "stm32g431kbt6",
-    "product_line": "STM32F407xx",
-    "variant": "STM32G431xx"
+    "product_line": "STM32G431xx",
+    "variant": "NUCLEO_G431KB"
   },
   "connectivity": [
     "can"

--- a/examples/arduino-blink/platformio.ini
+++ b/examples/arduino-blink/platformio.ini
@@ -44,6 +44,12 @@ board = nucleo_h743zi
 [env:nucleo_g071rb]
 board = nucleo_g071rb
 
+[env:nucleo_g431kb]
+board = nucleo_g431kb
+
+[env:nucleo_g431rb]
+board = nucleo_g431rb
+
 [env:robotdyn_blackpill_f303cc]
 board = robotdyn_blackpill_f303cc
 


### PR DESCRIPTION
The value of the **variant** is used to construct the path to the file variant.h:
.platformio/packages/framework-arduinoststm32/variants/**NUCLEO_G431KB**/variant.h

This was pointing to a nonexisting path, so the project did not compile.

I also added this board to the platformio.ini, so it can be chosen as Project Environment.

As a Christmas extra, I also added the missing NUCLEO_G431RB to env.

This PR relates to the ticket #460 