### PR TITLE
Fix the location of CMSIS-DSP header files for stm32cube framework.

### DIFF
--- a/builder/frameworks/stm32cube.py
+++ b/builder/frameworks/stm32cube.py
@@ -202,6 +202,7 @@ env.Append(
     CPPPATH=[
         "$PROJECT_SRC_DIR",
         "$PROJECT_INCLUDE_DIR",
+        os.path.join(FRAMEWORK_DIR, "Drivers", "CMSIS", "DSP", "Include"),
         os.path.join(FRAMEWORK_DIR, "Drivers", "CMSIS", "Include"),
         os.path.join(
             FRAMEWORK_DIR,


### PR DESCRIPTION
Hi, a special thanks to @valeros who solve quickly #458 issue. This worked very well when using the cmsis framework. 
Using stm32cube instead of cmsis framework, the same #458 happen.

So, this PR add the path of CMSIS-DSP math functions, to the CPPPATH for the stm32cube framework