### PR TITLE
Update disco_f407vg.json

### DIFF
--- a/boards/disco_f407vg.json
+++ b/boards/disco_f407vg.json
@@ -9,6 +9,9 @@
     "product_line": "STM32F407xx",
     "zephyr": {
        "variant": "stm32f4_disco"
+    },
+    "stm32cube": {
+       "variant": "STM32F4-Discovery"
     }
   },
   "debug": {


### PR DESCRIPTION
Includes STM32Cube "variant" to make it include the correct BSP folder at all times.