### PR TITLE
Enabled J-Link GUI for when selecting among multiple J-Links when uploading firmware

### DIFF
--- a/builder/main.py
+++ b/builder/main.py
@@ -173,8 +173,8 @@ elif upload_protocol.startswith("jlink"):
             "-device", board.get("debug", {}).get("jlink_device"),
             "-speed", "4000",
             "-if", ("jtag" if upload_protocol == "jlink-jtag" else "swd"),
-            "-autoconnect", "1",
-            "-NoGui", "1"
+            "-autoconnect", "1"
+            # "-NoGui", "1"  # this removes the option to select from multiple JLinks
         ],
         UPLOADCMD='$UPLOADER $UPLOADERFLAGS -CommanderScript "${__jlink_cmd_script(__env__, SOURCE)}"'
     )


### PR DESCRIPTION
As said in #464, setting  `"-NoGui", "1"` not only removes the upload progress bar but also removes the capability to select among multiple J-Links when uploading.