### PR TITLE
Add STM32F407IG generic board

### DIFF
--- a/boards/genericSTM32F407IGT6.json
+++ b/boards/genericSTM32F407IGT6.json
@@ -1,0 +1,56 @@
+{
+  "build": {
+    "core": "stm32",
+    "cpu": "cortex-m4",
+    "extra_flags": "-DSTM32F407xx -DSTM32F4",
+    "f_cpu": "168000000L",
+    "hwids": [
+      [
+        "0x1EAF",
+        "0x0003"
+      ],
+      [
+        "0x0483",
+        "0x3748"
+      ]
+    ],
+    "mcu": "stm32f407igt6",
+    "product_line": "STM32F407xx"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32F407IG",
+    "openocd_extra_args": [
+      "-c",
+      "reset_config none"
+    ],
+    "openocd_target": "stm32f4x",
+    "svd_path": "STM32F40x.svd"
+  },
+  "frameworks": [
+    "cmsis",
+    "stm32cube",
+    "libopencm3"
+  ],
+  "name": "STM32F407IG (192k RAM. 1024k Flash)",
+  "upload": {
+    "disable_flushing": false,
+    "maximum_ram_size": 196608,
+    "maximum_size": 1048576,
+    "protocol": "stlink",
+    "protocols": [
+      "blackmagic",
+      "dfu",
+      "jlink",
+      "serial",
+      "stlink"
+    ],
+    "require_upload_port": true,
+    "use_1200bps_touch": false,
+    "wait_for_upload_port": false
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32f407ig.html",
+  "vendor": "Generic"
+}


### PR DESCRIPTION
Hello,

I would like to add STM32F407VG generic board. This is useful for example to support [Waveshare Core407I](https://www.waveshare.com/wiki/Core407I) and Riscure Piñata board.

This is my first contribution to PlatformIO, if I messed something up please let me know and I will do my best.

Regards,