### PR TITLE
Update genericSTM32F411RE.json

### DIFF
--- a/boards/genericSTM32F411RE.json
+++ b/boards/genericSTM32F411RE.json
@@ -19,10 +19,10 @@
     "stm32cube",
     "libopencm3"
   ],
-  "name": "STM32F411RE (128k RAM. 256k Flash)",
+  "name": "STM32F411RE (128k RAM. 512k Flash)",
   "upload": {
     "maximum_ram_size": 131072,
-    "maximum_size": 262144,
+    "maximum_size": 524288,
     "protocol": "serial",
     "protocols": [
       "blackmagic",


### PR DESCRIPTION
STM32F411xE chips have 512kb Flash, see: https://www.st.com/en/microcontrollers-microprocessors/stm32f411re.html