### PR TITLE
Fix presumed copy paste error in STM32F0 example

### DIFF
--- a/examples/cmsis-blink/src/main.c
+++ b/examples/cmsis-blink/src/main.c
@@ -30,7 +30,7 @@
     #include "stm32f0xx.h"
     #define LEDPORT (GPIOC)
     #define LED1 (8)
-    #define ENABLE_GPIO_CLOCK (RCC->APB2ENR |= RCC_AHBENR_GPIOCEN)
+    #define ENABLE_GPIO_CLOCK (RCC->AHBENR |= RCC_AHBENR_GPIOCEN)
     #define _MODER    MODER
     #define GPIOMODER (GPIO_MODER_MODER8_0)
 #elif STM32F1


### PR DESCRIPTION
`RCC_AHBENR_GPIOCEN` is in `RCC->AHBENR` not `RCC->APB2ENR`

Found this issue when following this example. Pretty sure this is the simple fix. Thought it would be easiest to just make a PR. Not sure what the suggested base branch to use is.