### PR TITLE
Add generic STM32F105x boards

### DIFF
--- a/boards/genericSTM32F105R8.json
+++ b/boards/genericSTM32F105R8.json
@@ -1,0 +1,43 @@
+{
+  "build": {
+    "core": "stm32",
+    "cpu": "cortex-m3",
+    "extra_flags": "-DSTM32F105xC -DSTM32F1",
+    "f_cpu": "72000000L",
+    "mcu": "stm32f105r8t6",
+    "product_line": "STM32F105xC",
+    "variant": "Generic_F105Rx"
+  },
+  "debug": {
+    "jlink_device": "STM32F105R8",
+    "openocd_target": "stm32f1x",
+    "svd_path": "STM32F105xx.svd"
+  },
+  "frameworks": [
+    "arduino",
+    "cmsis",
+    "mbed",
+    "libopencm3",
+    "stm32cube"
+  ],
+  "name": "STM32F105R8 (64k RAM. 64k Flash)",
+  "upload": {
+    "disable_flushing": false,
+    "maximum_ram_size": 65536,
+    "maximum_size": 65536,
+    "protocol": "stlink",
+    "protocols": [
+      "jlink",
+      "cmsis-dap",
+      "stlink",
+      "blackmagic",
+      "serial",
+      "dfu"
+    ],
+    "require_upload_port": true,
+    "use_1200bps_touch": false,
+    "wait_for_upload_port": false
+  },
+  "url": "http://www.st.com/content/st_com/en/products/microcontrollers/stm32-32-bit-arm-cortex-mcus/stm32f1-series/stm32f105/stm32f105r8.html",
+  "vendor": "Generic"
+}

--- a/boards/genericSTM32F105RB.json
+++ b/boards/genericSTM32F105RB.json
@@ -1,0 +1,43 @@
+{
+  "build": {
+    "core": "stm32",
+    "cpu": "cortex-m3",
+    "extra_flags": "-DSTM32F105xC -DSTM32F1",
+    "f_cpu": "72000000L",
+    "mcu": "stm32f105rbt6",
+    "product_line": "STM32F105xC",
+    "variant": "Generic_F105Rx"
+  },
+  "debug": {
+    "jlink_device": "STM32F105RB",
+    "openocd_target": "stm32f1x",
+    "svd_path": "STM32F105xx.svd"
+  },
+  "frameworks": [
+    "arduino",
+    "cmsis",
+    "mbed",
+    "libopencm3",
+    "stm32cube"
+  ],
+  "name": "STM32F105RB (64k RAM. 128k Flash)",
+  "upload": {
+    "disable_flushing": false,
+    "maximum_ram_size": 65536,
+    "maximum_size": 131072,
+    "protocol": "stlink",
+    "protocols": [
+      "jlink",
+      "cmsis-dap",
+      "stlink",
+      "blackmagic",
+      "serial",
+      "dfu"
+    ],
+    "require_upload_port": true,
+    "use_1200bps_touch": false,
+    "wait_for_upload_port": false
+  },
+  "url": "http://www.st.com/content/st_com/en/products/microcontrollers/stm32-32-bit-arm-cortex-mcus/stm32f1-series/stm32f105/stm32f105rb.html",
+  "vendor": "Generic"
+}

--- a/boards/genericSTM32F105RC.json
+++ b/boards/genericSTM32F105RC.json
@@ -1,0 +1,43 @@
+{
+  "build": {
+    "core": "stm32",
+    "cpu": "cortex-m3",
+    "extra_flags": "-DSTM32F105xC -DSTM32F1",
+    "f_cpu": "72000000L",
+    "mcu": "stm32f105rct6",
+    "product_line": "STM32F105xC",
+    "variant": "Generic_F105Rx"
+  },
+  "debug": {
+    "jlink_device": "STM32F105RC",
+    "openocd_target": "stm32f1x",
+    "svd_path": "STM32F105xx.svd"
+  },
+  "frameworks": [
+    "arduino",
+    "cmsis",
+    "mbed",
+    "libopencm3",
+    "stm32cube"
+  ],
+  "name": "STM32F105RC (64k RAM. 256k Flash)",
+  "upload": {
+    "disable_flushing": false,
+    "maximum_ram_size": 65536,
+    "maximum_size": 262144,
+    "protocol": "stlink",
+    "protocols": [
+      "jlink",
+      "cmsis-dap",
+      "stlink",
+      "blackmagic",
+      "serial",
+      "dfu"
+    ],
+    "require_upload_port": true,
+    "use_1200bps_touch": false,
+    "wait_for_upload_port": false
+  },
+  "url": "http://www.st.com/content/st_com/en/products/microcontrollers/stm32-32-bit-arm-cortex-mcus/stm32f1-series/stm32f105/stm32f105rc.html",
+  "vendor": "Generic"
+}


### PR DESCRIPTION
This is a WIP work of adding new series, depending on https://github.com/ttimasdf/Arduino_Core_STM32/tree/variant-generic-stm32f105x being merged. maple core is not yet tested.

Fix #160 