### PR TITLE
Fix onboard STLink uploading and debugging for Nucleo-Gxxx series

### DIFF
--- a/boards/nucleo_g071rb.json
+++ b/boards/nucleo_g071rb.json
@@ -12,7 +12,13 @@
     "variant": "NUCLEO_G071RB"
   },
   "debug": {
+    "default_tools": [
+      "stlink"
+    ],
     "jlink_device": "STM32G071RB",
+    "onboard_tools": [
+      "stlink"
+    ],
     "openocd_target": "stm32g0x",
     "svd_path": "STM32G071.svd"
   },
@@ -27,8 +33,9 @@
   "upload": {
     "maximum_ram_size": 36864,
     "maximum_size": 131072,
-    "protocol": "mbed",
+    "protocol": "stlink",
     "protocols": [
+      "stlink",
       "jlink",
       "cmsis-dap",
       "blackmagic",

--- a/boards/nucleo_g431kb.json
+++ b/boards/nucleo_g431kb.json
@@ -12,7 +12,13 @@
     "can"
   ],
   "debug": {
+    "default_tools": [
+      "stlink"
+    ],
     "jlink_device": "STM32G431KB",
+    "onboard_tools": [
+      "stlink"
+    ],
     "openocd_target": "stm32g4x",
     "svd_path": "STM32G431xx.svd"
   },
@@ -26,8 +32,9 @@
   "upload": {
     "maximum_ram_size": 32768,
     "maximum_size": 131072,
-    "protocol": "mbed",
+    "protocol": "stlink",
     "protocols": [
+      "stlink",
       "jlink",
       "cmsis-dap",
       "blackmagic",

--- a/boards/nucleo_g431rb.json
+++ b/boards/nucleo_g431rb.json
@@ -12,7 +12,13 @@
     "can"
   ],
   "debug": {
+    "default_tools": [
+      "stlink"
+    ],
     "jlink_device": "STM32G431RB",
+    "onboard_tools": [
+      "stlink"
+    ],    
     "openocd_target": "stm32g4x",
     "svd_path": "STM32G431xx.svd"
   },
@@ -27,8 +33,9 @@
   "upload": {
     "maximum_ram_size": 32768,
     "maximum_size": 131072,
-    "protocol": "mbed",
+    "protocol": "stlink",
     "protocols": [
+      "stlink",
       "jlink",
       "cmsis-dap",
       "blackmagic",

--- a/boards/nucleo_g474re.json
+++ b/boards/nucleo_g474re.json
@@ -36,7 +36,7 @@
     "maximum_size": 524288,
     "protocol": "stlink",
     "protocols": [
-      "stlink"
+      "stlink",
       "jlink",
       "cmsis-dap",
       "blackmagic",

--- a/boards/nucleo_g474re.json
+++ b/boards/nucleo_g474re.json
@@ -12,7 +12,13 @@
     "can"
   ],
   "debug": {
+    "default_tools": [
+      "stlink"
+    ],
     "jlink_device": "STM32G474RE",
+    "onboard_tools": [
+      "stlink"
+    ],
     "openocd_target": "stm32g4x",
     "svd_path": "STM32G474xx.svd"
   },
@@ -28,8 +34,9 @@
   "upload": {
     "maximum_ram_size": 131072,
     "maximum_size": 524288,
-    "protocol": "mbed",
+    "protocol": "stlink",
     "protocols": [
+      "stlink"
       "jlink",
       "cmsis-dap",
       "blackmagic",


### PR DESCRIPTION
As per https://community.platformio.org/t/using-a-debugger-with-nucleo-g071rb/20233 and confirmed working.

All of these nucleos have the standard ST-Link V2/1 installed on them, but their manifest choses mbed as upload method. `stlink` is not listed and debugging via the STLink doesn't work by default.

PS: There was a bit of an intermezzo in the above thread because it was temporarily not working, but that seems to have been to matters unrelated to that, and at the end it was confirmed working for the Nucleo G071RB with the manifest changes made in this PR and the currently used OpenOCD version.

The PR directly fixes all Nucleo Gxxx series board manifests.