### PR TITLE
Fix numerous inconsistencies with some board's `extra_flag` and `product_line`

### DIFF
--- a/boards/blackpill_f103c8_128.json
+++ b/boards/blackpill_f103c8_128.json
@@ -2,7 +2,7 @@
   "build": {
     "core": "stm32",
     "cpu": "cortex-m3",
-    "extra_flags": "-DSTM32F1 -DSTM32F103xB",
+    "extra_flags": "-DSTM32F1 -DSTM32F103x8",
     "f_cpu": "72000000L",
     "hwids": [
       [
@@ -15,7 +15,7 @@
       ]
     ],
     "mcu": "stm32f103c8t6",
-    "product_line": "STM32F103xB",
+    "product_line": "STM32F103x8",
     "variant": "PILL_F103XX",
     "zephyr": {
        "variant": "stm32_min_dev_black"

--- a/boards/bluepill_f103c8.json
+++ b/boards/bluepill_f103c8.json
@@ -2,7 +2,7 @@
   "build": {
     "core": "stm32",
     "cpu": "cortex-m3",
-    "extra_flags": "-DSTM32F1 -DSTM32F103xB -DARDUINO_BLUEPILL_F103C8",
+    "extra_flags": "-DSTM32F1 -DSTM32F103x8 -DARDUINO_BLUEPILL_F103C8",
     "f_cpu": "72000000L",
     "hwids": [
       [
@@ -15,7 +15,7 @@
       ]
     ],
     "mcu": "stm32f103c8t6",
-    "product_line": "STM32F103xB",
+    "product_line": "STM32F103x8",
     "variant": "PILL_F103XX",
     "zephyr": {
        "variant": "stm32_min_dev_blue"

--- a/boards/bluepill_f103c8_128k.json
+++ b/boards/bluepill_f103c8_128k.json
@@ -2,7 +2,7 @@
   "build": {
     "core": "stm32",
     "cpu": "cortex-m3",
-    "extra_flags": "-DSTM32F1 -DSTM32F103xB -DARDUINO_BLUEPILL_F103C8",
+    "extra_flags": "-DSTM32F1 -DSTM32F103x8 -DARDUINO_BLUEPILL_F103C8",
     "f_cpu": "72000000L",
     "hwids": [
       [
@@ -15,7 +15,7 @@
       ]
     ],
     "mcu": "stm32f103c8t6",
-    "product_line": "STM32F103xB",
+    "product_line": "STM32F103x8",
     "variant": "PILL_F103XX",
     "zephyr": {
        "variant": "stm32_min_dev_blue"

--- a/boards/genericSTM32F103C8.json
+++ b/boards/genericSTM32F103C8.json
@@ -2,7 +2,7 @@
   "build": {
     "core": "stm32",
     "cpu": "cortex-m3",
-    "extra_flags": "-DSTM32F103xB -DSTM32F1",
+    "extra_flags": "-DSTM32F103x8 -DSTM32F1",
     "f_cpu": "72000000L",
     "hwids": [
       [
@@ -15,7 +15,7 @@
       ]
     ],
     "mcu": "stm32f103c8t6",
-    "product_line": "STM32F103xB",
+    "product_line": "STM32F103x8",
     "variant": "Generic_F103Cx"
   },
   "debug": {

--- a/boards/genericSTM32F103R4.json
+++ b/boards/genericSTM32F103R4.json
@@ -2,10 +2,10 @@
   "build": {
     "core": "stm32",
     "cpu": "cortex-m3",
-    "extra_flags": "-DSTM32F103x6 -DSTM32F1",
+    "extra_flags": "-DSTM32F103x4 -DSTM32F1",
     "f_cpu": "72000000L",
     "mcu": "stm32f103r4",
-    "product_line": "STM32F103x6",
+    "product_line": "STM32F103x4",
     "variant": "Generic_F103Rx"
   },
   "debug": {

--- a/boards/genericSTM32F103R8.json
+++ b/boards/genericSTM32F103R8.json
@@ -2,7 +2,7 @@
   "build": {
     "core": "stm32",
     "cpu": "cortex-m3",
-    "extra_flags": "-DSTM32F103xB -DSTM32F1",
+    "extra_flags": "-DSTM32F103x8 -DSTM32F1",
     "f_cpu": "72000000L",
     "hwids": [
       [
@@ -15,7 +15,7 @@
       ]
     ],
     "mcu": "stm32f103r8t6",
-    "product_line": "STM32F103xB",
+    "product_line": "STM32F103x8",
     "variant": "Generic_F103Rx"
   },
   "debug": {

--- a/boards/genericSTM32F103RC.json
+++ b/boards/genericSTM32F103RC.json
@@ -2,7 +2,7 @@
   "build": {
     "core": "stm32",
     "cpu": "cortex-m3",
-    "extra_flags": "-DSTM32F103xE -DSTM32F1",
+    "extra_flags": "-DSTM32F103xC -DSTM32F1",
     "f_cpu": "72000000L",
     "hwids": [
       [
@@ -15,7 +15,7 @@
       ]
     ],
     "mcu": "stm32f103rct6",
-    "product_line": "STM32F103xE",
+    "product_line": "STM32F103xC",
     "variant": "Generic_F103Rx"
   },
   "debug": {

--- a/boards/genericSTM32F103RD.json
+++ b/boards/genericSTM32F103RD.json
@@ -2,10 +2,10 @@
   "build": {
     "core": "stm32",
     "cpu": "cortex-m3",
-    "extra_flags": "-DSTM32F103xE -DSTM32F1",
+    "extra_flags": "-DSTM32F103xD -DSTM32F1",
     "f_cpu": "72000000L",
     "mcu": "stm32f103rd",
-    "product_line": "STM32F103xE",
+    "product_line": "STM32F103xD",
     "variant": "Generic_F103Rx"
   },
   "debug": {

--- a/boards/genericSTM32F103RF.json
+++ b/boards/genericSTM32F103RF.json
@@ -2,10 +2,10 @@
   "build": {
     "core": "stm32",
     "cpu": "cortex-m3",
-    "extra_flags": "-DSTM32F103xE -DSTM32F1",
+    "extra_flags": "-DSTM32F103xF -DSTM32F1",
     "f_cpu": "72000000L",
     "mcu": "stm32f103rf",
-    "product_line": "STM32F103xE",
+    "product_line": "STM32F103xF",
     "variant": "Generic_F103Rx"
   },
   "debug": {

--- a/boards/genericSTM32F103RG.json
+++ b/boards/genericSTM32F103RG.json
@@ -2,10 +2,10 @@
   "build": {
     "core": "stm32",
     "cpu": "cortex-m3",
-    "extra_flags": "-DSTM32F103xE -DSTM32F1",
+    "extra_flags": "-DSTM32F103xG -DSTM32F1",
     "f_cpu": "72000000L",
     "mcu": "stm32f103rg",
-    "product_line": "STM32F103xE",
+    "product_line": "STM32F103xG",
     "variant": "Generic_F103Rx"
   },
   "debug": {

--- a/boards/genericSTM32F103T4.json
+++ b/boards/genericSTM32F103T4.json
@@ -2,10 +2,10 @@
   "build": {
     "core": "stm32",
     "cpu": "cortex-m3",
-    "extra_flags": "-DSTM32F103x6 -DSTM32F1",
+    "extra_flags": "-DSTM32F103x4 -DSTM32F1",
     "f_cpu": "72000000L",
     "mcu": "stm32f103t4",
-    "product_line": "STM32F103x6",
+    "product_line": "STM32F103x4",
     "variant": "Generic_F103Tx"
   },
   "debug": {

--- a/boards/genericSTM32F103T8.json
+++ b/boards/genericSTM32F103T8.json
@@ -2,7 +2,7 @@
   "build": {
     "core": "stm32",
     "cpu": "cortex-m3",
-    "extra_flags": "-DSTM32F103xB -DSTM32F1",
+    "extra_flags": "-DSTM32F103x8 -DSTM32F1",
     "f_cpu": "72000000L",
     "hwids": [
       [
@@ -15,7 +15,7 @@
       ]
     ],
     "mcu": "stm32f103t8t6",
-    "product_line": "STM32F103xB",
+    "product_line": "STM32F103x8",
     "variant": "Generic_F103Tx"
   },
   "debug": {

--- a/boards/genericSTM32F103V8.json
+++ b/boards/genericSTM32F103V8.json
@@ -2,10 +2,10 @@
   "build": {
     "core": "stm32",
     "cpu": "cortex-m3",
-    "extra_flags": "-DSTM32F103xB -DSTM32F1",
+    "extra_flags": "-DSTM32F103x8 -DSTM32F1",
     "f_cpu": "72000000L",
     "mcu": "stm32f103v8",
-    "product_line": "STM32F103xB",
+    "product_line": "STM32F103x8",
     "variant": "Generic_F103Vx"
   },
   "debug": {

--- a/boards/genericSTM32F103VC.json
+++ b/boards/genericSTM32F103VC.json
@@ -2,7 +2,7 @@
   "build": {
     "core": "stm32",
     "cpu": "cortex-m3",
-    "extra_flags": "-DSTM32F103xE -DSTM32F1",
+    "extra_flags": "-DSTM32F103xC -DSTM32F1",
     "f_cpu": "72000000L",
     "hwids": [
       [
@@ -15,7 +15,7 @@
       ]
     ],
     "mcu": "stm32f103vct6",
-    "product_line": "STM32F103xE",
+    "product_line": "STM32F103xC",
     "variant": "Generic_F103Vx"
   },
   "debug": {

--- a/boards/genericSTM32F103VD.json
+++ b/boards/genericSTM32F103VD.json
@@ -2,7 +2,7 @@
   "build": {
     "core": "stm32",
     "cpu": "cortex-m3",
-    "extra_flags": "-DSTM32F103xE -DSTM32F1",
+    "extra_flags": "-DSTM32F103xD -DSTM32F1",
     "f_cpu": "72000000L",
     "hwids": [
       [
@@ -15,7 +15,7 @@
       ]
     ],
     "mcu": "stm32f103vdt6",
-    "product_line": "STM32F103xE",
+    "product_line": "STM32F103xD",
     "variant": "Generic_F103Vx"
   },
   "debug": {

--- a/boards/genericSTM32F103VF.json
+++ b/boards/genericSTM32F103VF.json
@@ -2,10 +2,10 @@
   "build": {
     "core": "stm32",
     "cpu": "cortex-m3",
-    "extra_flags": "-DSTM32F103xG -DSTM32F1",
+    "extra_flags": "-DSTM32F103xF -DSTM32F1",
     "f_cpu": "72000000L",
     "mcu": "stm32f103vf",
-    "product_line": "STM32F103xG",
+    "product_line": "STM32F103xF",
     "variant": "Generic_F103Vx"
   },
   "debug": {

--- a/boards/genericSTM32F103ZC.json
+++ b/boards/genericSTM32F103ZC.json
@@ -2,7 +2,7 @@
   "build": {
     "core": "stm32",
     "cpu": "cortex-m3",
-    "extra_flags": "-DSTM32F103xE -DSTM32F1",
+    "extra_flags": "-DSTM32F103xC -DSTM32F1",
     "f_cpu": "72000000L",
     "hwids": [
       [
@@ -15,7 +15,7 @@
       ]
     ],
     "mcu": "stm32f103zct6",
-    "product_line": "STM32F103xE",
+    "product_line": "STM32F103xC",
     "variant": "Generic_F103Zx"
   },
   "debug": {

--- a/boards/genericSTM32F103ZD.json
+++ b/boards/genericSTM32F103ZD.json
@@ -2,7 +2,7 @@
   "build": {
     "core": "stm32",
     "cpu": "cortex-m3",
-    "extra_flags": "-DSTM32F103xE -DSTM32F1",
+    "extra_flags": "-DSTM32F103xD -DSTM32F1",
     "f_cpu": "72000000L",
     "hwids": [
       [
@@ -15,7 +15,7 @@
       ]
     ],
     "mcu": "stm32f103zdt6",
-    "product_line": "STM32F103xE",
+    "product_line": "STM32F103xD",
     "variant": "Generic_F103Zx"
   },
   "debug": {

--- a/boards/genericSTM32F103ZF.json
+++ b/boards/genericSTM32F103ZF.json
@@ -2,10 +2,10 @@
   "build": {
     "core": "stm32",
     "cpu": "cortex-m3",
-    "extra_flags": "-DSTM32F103xG -DSTM32F1",
+    "extra_flags": "-DSTM32F103xF -DSTM32F1",
     "f_cpu": "72000000L",
     "mcu": "stm32f103zf",
-    "product_line": "STM32F103xG",
+    "product_line": "STM32F103xF",
     "variant": "Generic_F103Zx"
   },
   "debug": {

--- a/boards/genericSTM32F303CB.json
+++ b/boards/genericSTM32F303CB.json
@@ -2,10 +2,10 @@
   "build": {
     "core": "stm32",
     "cpu": "cortex-m4",
-    "extra_flags": "-DSTM32F3 -DSTM32F303xC",
+    "extra_flags": "-DSTM32F3 -DSTM32F303xB",
     "f_cpu": "72000000L",
     "mcu": "stm32f303cbt6",
-    "product_line": "STM32F303xC"
+    "product_line": "STM32F303xB"
   },
   "connectivity": [
     "can"

--- a/boards/genericSTM32F401CB.json
+++ b/boards/genericSTM32F401CB.json
@@ -2,10 +2,10 @@
   "build": {
     "core": "stm32",
     "cpu": "cortex-m4",
-    "extra_flags": "-DSTM32F401xC -DSTM32F4xx",
+    "extra_flags": "-DSTM32F401xB -DSTM32F4xx",
     "f_cpu": "84000000L",
     "mcu": "stm32f401cb",
-    "product_line": "STM32F401xC",
+    "product_line": "STM32F401xB",
     "variant": "Generic_F401Cx"
   },
   "debug": {

--- a/boards/genericSTM32F401CD.json
+++ b/boards/genericSTM32F401CD.json
@@ -2,10 +2,10 @@
   "build": {
     "core": "stm32",
     "cpu": "cortex-m4",
-    "extra_flags": "-DSTM32F401xE -DSTM32F4xx",
+    "extra_flags": "-DSTM32F401xD -DSTM32F4xx",
     "f_cpu": "84000000L",
     "mcu": "stm32f401cd",
-    "product_line": "STM32F401xE",
+    "product_line": "STM32F401xD",
     "variant": "Generic_F401Cx"
   },
   "debug": {

--- a/boards/genericSTM32F401RB.json
+++ b/boards/genericSTM32F401RB.json
@@ -2,10 +2,10 @@
   "build": {
     "core": "stm32",
     "cpu": "cortex-m4",
-    "extra_flags": "-DSTM32F401xC -DSTM32F4xx",
+    "extra_flags": "-DSTM32F401xB -DSTM32F4xx",
     "f_cpu": "84000000L",
     "mcu": "stm32f401rb",
-    "product_line": "STM32F401xC",
+    "product_line": "STM32F401xB",
     "variant": "Generic_F401Rx"
   },
   "debug": {

--- a/boards/genericSTM32F401RD.json
+++ b/boards/genericSTM32F401RD.json
@@ -2,10 +2,10 @@
   "build": {
     "core": "stm32",
     "cpu": "cortex-m4",
-    "extra_flags": "-DSTM32F401xE -DSTM32F4xx",
+    "extra_flags": "-DSTM32F401xD -DSTM32F4xx",
     "f_cpu": "84000000L",
     "mcu": "stm32f401rd",
-    "product_line": "STM32F401xE",
+    "product_line": "STM32F401xD",
     "variant": "Generic_F401Rx"
   },
   "debug": {

--- a/boards/genericSTM32F411CC.json
+++ b/boards/genericSTM32F411CC.json
@@ -2,10 +2,10 @@
   "build": {
     "core": "stm32",
     "cpu": "cortex-m4",
-    "extra_flags": "-DSTM32F411xE -DSTM32F4xx",
+    "extra_flags": "-DSTM32F411xC -DSTM32F4xx",
     "f_cpu": "100000000L",
     "mcu": "stm32f411cc",
-    "product_line": "STM32F411xE",
+    "product_line": "STM32F411xC",
     "variant": "Generic_F411Cx"
   },
   "debug": {

--- a/boards/genericSTM32F411RC.json
+++ b/boards/genericSTM32F411RC.json
@@ -2,10 +2,10 @@
   "build": {
     "core": "stm32",
     "cpu": "cortex-m4",
-    "extra_flags": "-DSTM32F411xE -DSTM32F4xx",
+    "extra_flags": "-DSTM32F411xC -DSTM32F4xx",
     "f_cpu": "100000000L",
     "mcu": "stm32f411rc",
-    "product_line": "STM32F411xE",
+    "product_line": "STM32F411xC",
     "variant": "Generic_F411Rx"
   },
   "debug": {


### PR DESCRIPTION
Maybe this will help resolve issue https://github.com/platformio/platform-ststm32/issues/502 ? The change certainly shouldn't hurt.

Some boards like STM32F103C8T6 BluePill have the wrong SoC as `extra flag`. Example for STM32F103C8T6 BluePill `-DSTM32F103xB` should be `-DSTM32F103x8` since the B variant is different with more memory.

I looked over some of the other "Generic" files and fixed inconsistencies I saw.