### PR TITLE
Updates to blackpill series of boards

### DIFF
--- a/boards/blackpill_f401cc.json
+++ b/boards/blackpill_f401cc.json
@@ -8,9 +8,6 @@
     "product_line": "STM32F401xC",
     "variant": "Generic_F401Cx"
   },
-  "connectivity": [
-    "can"
-  ],
   "debug": {
     "jlink_device": "STM32F401CC",
     "openocd_target": "stm32f4x",
@@ -22,7 +19,7 @@
     "stm32cube",
     "libopencm3"
   ],
-  "name": "BlackPill F401CC",
+  "name": "WeAct Studio BlackPill V2.0 (STM32F401CC)",
   "upload": {
     "maximum_ram_size": 65536,
     "maximum_size": 262144,
@@ -36,6 +33,6 @@
       "dfu"
     ]
   },
-  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32f401cc.html",
-  "vendor": "ST"
+  "url": "https://github.com/WeActTC/MiniSTM32F4x1",
+  "vendor": "WeAct Studio"
 }

--- a/boards/blackpill_f401ce.json
+++ b/boards/blackpill_f401ce.json
@@ -8,9 +8,6 @@
     "product_line": "STM32F401xE",
     "variant": "Generic_F401Cx"
   },
-  "connectivity": [
-    "can"
-  ],
   "debug": {
     "jlink_device": "STM32F401CE",
     "openocd_target": "stm32f4x",
@@ -22,7 +19,7 @@
     "stm32cube",
     "libopencm3"
   ],
-  "name": "BlackPill F401CE",
+  "name": "WeAct Studio BlackPill V3.0 (STM32F401CE)",
   "upload": {
     "maximum_ram_size": 98304,
     "maximum_size": 524288,
@@ -36,6 +33,6 @@
       "dfu"
     ]
   },
-  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32f401ce.html",
-  "vendor": "ST"
+  "url": "https://github.com/WeActTC/MiniSTM32F4x1",
+  "vendor": "WeAct Studio"
 }

--- a/boards/blackpill_f401ce.json
+++ b/boards/blackpill_f401ce.json
@@ -6,7 +6,10 @@
     "f_cpu": "84000000L",
     "mcu": "stm32f401ceu6",
     "product_line": "STM32F401xE",
-    "variant": "Generic_F401Cx"
+    "variant": "Generic_F401Cx",
+    "zephyr": {
+      "variant": "blackpill_f401ce"
+    }
   },
   "debug": {
     "jlink_device": "STM32F401CE",
@@ -17,7 +20,8 @@
     "arduino",
     "cmsis",
     "stm32cube",
-    "libopencm3"
+    "libopencm3",
+    "zephyr"
   ],
   "name": "WeAct Studio BlackPill V3.0 (STM32F401CE)",
   "upload": {

--- a/boards/blackpill_f411ce.json
+++ b/boards/blackpill_f411ce.json
@@ -6,7 +6,10 @@
     "f_cpu": "100000000L",
     "mcu": "stm32f411ceu6",
     "product_line": "STM32F411xE",
-    "variant": "Generic_F411Cx"
+    "variant": "Generic_F411Cx",
+    "zephyr": {
+      "variant": "blackpill_f411ce"
+    }
   },
   "debug": {
     "jlink_device": "STM32F411CE",

--- a/boards/blackpill_f411ce.json
+++ b/boards/blackpill_f411ce.json
@@ -8,9 +8,6 @@
     "product_line": "STM32F411xE",
     "variant": "Generic_F411Cx"
   },
-  "connectivity": [
-    "can"
-  ],
   "debug": {
     "jlink_device": "STM32F411CE",
     "openocd_target": "stm32f4x",
@@ -23,7 +20,7 @@
     "libopencm3",
     "zephyr"
   ],
-  "name": "WeAct BlackPill V2.0 (BlackPill F411CE)",
+  "name": "WeAct Studio BlackPill V2.0 (STM32F411CE)",
   "upload": {
     "maximum_ram_size": 131072,
     "maximum_size": 524288,
@@ -37,6 +34,6 @@
       "dfu"
     ]
   },
-  "url": "https://github.com/mcauser/WEACT_F411CEU6",
-  "vendor": "WeAct"
+  "url": "https://github.com/WeActTC/MiniSTM32F4x1",
+  "vendor": "WeAct Studio"
 }


### PR DESCRIPTION
Hello! Here are some updates to the WeAct black pill boards (F401CC, F401CE, F411CE). When I first added these boards, I think I copied the F401CE and F401CC from the F411CE definition without checking it carefully enough, so a couple of things slipped in, like CAN connectivity. Actually, not sure how that came in - none of these boards have CAN, so I removed that. I also updated the names a little.

Additionally, back when I contributed these boards, they didn't have support in zephyr - but since then, I've added upstream zephyr support for the F401CE and F411CE (`blackpill_f401ce` and `blackpill_f411ce`) so I added framework support here. I'm not sure if anything else needs to be done such as modifications to platformio's zephyr fork, but please let me know if I need to add anything else!