### PR TITLE
Setup local env instance for debugging.

### DIFF
--- a/builder/frameworks/stm32cube.py
+++ b/builder/frameworks/stm32cube.py
@@ -251,6 +251,9 @@ env.Append(
     LIBS=["c", "gcc", "m", "stdc++", "nosys"],
 )
 
+if env.GetBuildType() == "debug":
+    env.ConfigureDebugFlags()
+
 # copy CCFLAGS to ASFLAGS (-x assembler-with-cpp mode)
 env.Append(ASFLAGS=env.get("CCFLAGS", [])[:])
 


### PR DESCRIPTION
It seems that `stm32cube` platforms compiles BSP files using local `env` instance with hardcoded `-Os` flag. 

As a result, if `platformio.ini` contains `build_type = debug`, BSP code is compiled without debug symbols. On the contrary, HAL files are properly compiled for debugging, so it is somewhat inconsistent. 

Note: my fix works for me, but I'm not sure if it is the best way to do it, as I'm not exactly familiar with `SCons` and `PlatformIO` builds philosophy.