### PR TITLE
Add arduino frameworks support for nucleo_wl55jc

### DIFF
--- a/boards/nucleo_wl55jc.json
+++ b/boards/nucleo_wl55jc.json
@@ -1,11 +1,18 @@
 {
   "build": {
+    "arduino": {
+        "variant_h": "variant_NUCLEO_WL55JC1.h"
+    },
     "core": "stm32",
     "cpu": "cortex-m4",
     "extra_flags": "-DSTM32WL55JC1",
+    "framework_extra_flags": {
+        "arduino": "-DSTM32WL55xx -DUSE_CM4_STARTUP_FILE -DARDUINO_NUCLEO_WL55JC1"
+    },
     "f_cpu": "48000000L",
     "mcu": "stm32wl55jc",
-    "product_line": "STM32WL55xx"
+    "product_line": "STM32WL55xx",
+    "variant": "STM32WLxx/WL54JCI_WL55JCI_WLE4J(8-B-C)I_WLE5J(8-B-C)I"
   },
   "debug": {
     "default_tools": [
@@ -19,6 +26,11 @@
     "svd_path": "STM32WL5x_CM4.svd"
   },
   "frameworks": [
+    "arduino",
+    "cmsis",
+    "mbed",
+    "stm32cube",
+    "libopencm3",
     "zephyr"
   ],
   "name": "ST Nucleo WL55JC",

--- a/platform.json
+++ b/platform.json
@@ -192,7 +192,7 @@
       "type": "framework",
       "optional": true,
       "owner": "platformio",
-      "version": "~4.20000.0"
+      "version": "~4.30000.0"
     },
     "framework-arduinoststm32-maple": {
       "type": "framework",


### PR DESCRIPTION
This PR fixes issue #552 . It depends on https://github.com/stm32duino/Arduino_Core_STM32/pull/1474 to be merged and included in version 2.1.0 release of Arduino Core STM32. With local forks of that PR and this PR a basic blink sketch compiles, uploads and debugs correctly using the following `plaformio.ini` and `src/main.cpp`
```
[env:stm32wl55]
platform = ststm32
board = nucleo_wl55jc
framework = arduino
```

```
#include <Arduino.h>

void setup() {
    pinMode(LED_BUILTIN, OUTPUT);
}

void loop() {
    digitalWrite(LED_BUILTIN, !digitalRead(LED_BUILTIN));
    delay(1000);

}
```