### PR TITLE
Fix compatibility with the recent versions of STM32CubeMx

### DIFF
--- a/builder/frameworks/stm32cube.py
+++ b/builder/frameworks/stm32cube.py
@@ -46,6 +46,9 @@ FRAMEWORK_DIR = platform.get_package_dir("framework-stm32cube%s" % MCU[5:7])
 LDSCRIPTS_DIR = platform.get_package_dir("tool-ldscripts-ststm32")
 assert all(os.path.isdir(d) for d in (FRAMEWORK_DIR, LDSCRIPTS_DIR))
 
+if 'Core' in os.listdir(os.path.join(env['PROJECT_DIR'])):
+    env['PROJECT_SRC_DIR'] = os.path.join(env['PROJECT_DIR'], 'Core/Src')
+    env['PROJECT_INCLUDE_DIR'] = os.path.join(env['PROJECT_DIR'], 'Core/Inc')
 
 class CustomLibBuilder(PlatformIOLibBuilder):
 

--- a/builder/frameworks/stm32cube.py
+++ b/builder/frameworks/stm32cube.py
@@ -46,9 +46,9 @@ FRAMEWORK_DIR = platform.get_package_dir("framework-stm32cube%s" % MCU[5:7])
 LDSCRIPTS_DIR = platform.get_package_dir("tool-ldscripts-ststm32")
 assert all(os.path.isdir(d) for d in (FRAMEWORK_DIR, LDSCRIPTS_DIR))
 
-if 'Core' in os.listdir(os.path.join(env['PROJECT_DIR'])):
-    env['PROJECT_SRC_DIR'] = os.path.join(env['PROJECT_DIR'], 'Core/Src')
-    env['PROJECT_INCLUDE_DIR'] = os.path.join(env['PROJECT_DIR'], 'Core/Inc')
+if 'Core' in os.listdir(env['PROJECT_DIR']):
+    env['PROJECT_SRC_DIR'] = os.path.join(env['PROJECT_DIR'], 'Core','Src')
+    env['PROJECT_INCLUDE_DIR'] = os.path.join(env['PROJECT_DIR'], 'Core','Inc')
 
 class CustomLibBuilder(PlatformIOLibBuilder):
 


### PR DESCRIPTION
In the recent STM32CubeMX versions, the generated project folder structure has changed a little.

Now the files .c and .h is under the Core/ folder, as you can see below.

![image](https://user-images.githubusercontent.com/28740470/131260471-d88dbe33-70ff-460f-80c2-52f3118c0397.png)

So, this PR add changes to the stm32cube builder script:

It detect if the project dir contains the Core/ folder, if it has, add Core/Src to PROJECT_SRC_DIR var, and the same for the INCLUDE var..

With this changes, It is no longer necessary add the code below to the platformio.ini file:

```
[platformio]
include_dir = Core/Inc
src_dir = Core/Src
```