### PR TITLE
added libopencm3 as possible framework for ST B-G431B-ESC1 Discovery

### DIFF
--- a/boards/disco_b_g431b_esc1.json
+++ b/boards/disco_b_g431b_esc1.json
@@ -28,7 +28,8 @@
   "frameworks": [
     "arduino",
     "cmsis",
-    "stm32cube"
+    "stm32cube",
+    "libopencm3"
   ],
   "name": "ST B-G431B-ESC1 Discovery",
   "upload": {


### PR DESCRIPTION
The STM32G431 microcontroller on this board is supported by libopencm3 so I added it to the list of frameworks in the board file