### PR TITLE
OpenCR Board Support

### DIFF
--- a/boards/opencr.json
+++ b/boards/opencr.json
@@ -1,0 +1,28 @@
+{
+  "build": {
+    "extra_flags": "-mthumb  -DSTM32F746xx -D__OPENCR__",
+    "core": "opencr",
+    "cpu": "cortex-m7",
+    "f_cpu": "216000000L",
+    "mcu": "stm32f746zgt6",
+    "product_line": "STM32F746xx",
+    "variant": "OpenCR"
+  },
+  "connectivity": [
+    "can",
+    "ethernet"
+  ],
+  "frameworks": ["arduino"],
+  "platforms": ["ststm32"],
+  "name": "OpenCR 1.0",
+  "url": "https://emanual.robotis.com/docs/en/parts/controller/opencr10/",
+  "vendor": "ROBOTIS",
+  "upload": {
+    "maximum_ram_size": 256788,
+    "maximum_size": 786432,
+    "protocol": "custom",
+    "protocols": [
+      "custom"
+    ]
+  }
+}

--- a/builder/frameworks/arduino.py
+++ b/builder/frameworks/arduino.py
@@ -39,6 +39,10 @@ elif core == "stm32l0":
     build_script = join(
         env.PioPlatform().get_package_dir("framework-arduinoststm32l0"),
         "tools", "platformio-build.py")
+elif core == "opencr":
+    build_script = join(
+        env.PioPlatform().get_package_dir("framework-arduinoststm32-opencr"),
+        "tools", "platformio", "platformio-build.py")
 else:
     build_script = join(env.PioPlatform().get_package_dir(
         "framework-arduinoststm32"), "tools", "platformio", "platformio-build.py")

--- a/platform.json
+++ b/platform.json
@@ -194,6 +194,12 @@
       "owner": "platformio",
       "version": "~4.20200.0"
     },
+    "framework-arduinoststm32-opencr": {
+      "type": "framework",
+      "optional": true,
+      "owner": "platformio",
+      "version": "~1.4.18"
+    },
     "framework-arduinoststm32-maple": {
       "type": "framework",
       "optional": true,

--- a/platform.py
+++ b/platform.py
@@ -38,6 +38,11 @@ class Ststm32Platform(PlatformBase):
                     "script"
                 ] = "builder/frameworks/arduino/mbed-core/arduino-core-mbed.py"
                 self.packages["framework-arduinoststm32"]["optional"] = True
+            elif build_core == "opencr":
+                self.frameworks["arduino"]["package"] = "framework-arduinoststm32-opencr"
+                self.packages["framework-arduinoststm32-opencr"]["optional"] = False
+                self.packages["framework-arduinoststm32"]["optional"] = True
+                self.packages["framework-cmsis"]["optional"] = False
             elif build_core == "maple":
                 self.frameworks["arduino"]["package"] = "framework-arduinoststm32-maple"
                 self.packages["framework-arduinoststm32-maple"]["optional"] = False


### PR DESCRIPTION
This PR adds support for the OpenCR board.

It has been tested as part of an integration work of Zenoh technologies into OpenCR (you can find details here: https://zenoh.io/blog/2022-02-08-dragonbot/ ).

Since we believe that it might help others to develop to OpenCR boards using PlatformIO, we decided to share with the rest of the community.

Related to issue #140 .

