### PR TITLE
Add support for STM32G030 targets

### DIFF
--- a/boards/genericSTM32G030C8.json
+++ b/boards/genericSTM32G030C8.json
@@ -1,0 +1,43 @@
+{
+  "build": {
+    "core": "stm32",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DSTM32G030xx -DSTM32G0xx",
+    "f_cpu": "64000000L",
+    "framework_extra_flags": {
+      "arduino": "-D__CORTEX_SC=0"
+    },
+    "mcu": "stm32g030c8t6",
+    "product_line": "STM32G030xx",
+    "variant": "STM32G0xx/G030C(6-8)T"
+  },
+  "debug": {
+    "jlink_device": "STM32G030C8",
+    "openocd_target": "stm32g0x",
+    "svd_path": "STM32G030.svd"
+  },
+  "frameworks": [
+    "arduino",
+    "cmsis",
+    "mbed",
+    "libopencm3",
+    "stm32cube"
+  ],
+  "name": "STM32G030C8 (8k RAM. 64k Flash)",
+  "upload": {
+    "maximum_ram_size": 8192,
+    "maximum_size": 65536,
+    "protocol": "stlink",
+    "protocols": [
+      "jlink",
+      "cmsis-dap",
+      "stlink",
+      "blackmagic",
+      "serial",
+      "dfu"
+    ]
+  },
+  "url": "https://www.st.com/content/st_com/en/products/microcontrollers-microprocessors/stm32-32-bit-arm-cortex-mcus/stm32-mainstream-mcus/stm32g0-series/stm32g0x0-value-line/stm32g030c8.html",
+  "vendor": "Generic"
+}
+

--- a/boards/genericSTM32G030F6.json
+++ b/boards/genericSTM32G030F6.json
@@ -1,0 +1,43 @@
+{
+  "build": {
+    "core": "stm32",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DSTM32G030xx -DSTM32G0xx",
+    "f_cpu": "64000000L",
+    "framework_extra_flags": {
+      "arduino": "-D__CORTEX_SC=0"
+    },
+    "mcu": "stm32g030f6px",
+    "product_line": "STM32G030xx",
+    "variant": "STM32G0xx/G030F6P"
+  },
+  "debug": {
+    "jlink_device": "STM32G030F6",
+    "openocd_target": "stm32g0x",
+    "svd_path": "STM32G030.svd"
+  },
+  "frameworks": [
+    "arduino",
+    "cmsis",
+    "mbed",
+    "libopencm3",
+    "stm32cube"
+  ],
+  "name": "STM32G030C8 (8k RAM. 32k Flash)",
+  "upload": {
+    "maximum_ram_size": 8192,
+    "maximum_size": 32768,
+    "protocol": "stlink",
+    "protocols": [
+      "jlink",
+      "cmsis-dap",
+      "stlink",
+      "blackmagic",
+      "serial",
+      "dfu",
+    ]
+  },
+  "url": "https://www.st.com/content/st_com/en/products/microcontrollers-microprocessors/stm32-32-bit-arm-cortex-mcus/stm32-mainstream-mcus/stm32g0-series/stm32g0x0-value-line/stm32g030f6.html",
+  "vendor": "Generic"
+}
+


### PR DESCRIPTION
Support `STM32G030F6` and `STM32G030C8`, see https://github.com/stm32duino/Arduino_Core_STM32/commit/4d230128c7265a073d8e141f9ea9e5c83f44f0ba