### PR TITLE
Adding mbed support for Nucleo-WL55JC

### DIFF
--- a/boards/nucleo_wl55jc.json
+++ b/boards/nucleo_wl55jc.json
@@ -24,7 +24,8 @@
   },
   "frameworks": [
     "arduino",
-    "zephyr"
+    "zephyr",
+    "mbed"
   ],
   "name": "ST Nucleo WL55JC",
   "upload": {


### PR DESCRIPTION
Mbed has support for the Nucleo-WL55JC board.

https://os.mbed.com/platforms/ST-Nucleo-WL55JC/

I've run some basic blinky tests and everything seems to work as expected.