### PR TITLE
Updated used dfu-util to latest version available

### DIFF
--- a/platform.json
+++ b/platform.json
@@ -324,7 +324,7 @@
       "type": "uploader",
       "optional": true,
       "owner": "platformio",
-      "version": "~1.9.190708"
+      "version": "~1.11.0"
     },
     "tool-cmake": {
       "optional": true,


### PR DESCRIPTION
Platformio now has dfu-util 0.11 available in package tool-dfuutil.
See https://registry.platformio.org/tools/platformio/tool-dfuutil

I suggest that regression test is done by tooling and/or regular users before merging. 