### PR TITLE
Fix OpenOCD config for nucleo_wb55rg_p

### DIFF
--- a/boards/nucleo_wb55rg_p.json
+++ b/boards/nucleo_wb55rg_p.json
@@ -15,7 +15,7 @@
     "default_tools": [
       "stlink"
     ],
-    "openocd_target": "stm32w55xx",
+    "openocd_board": "st_nucleo_wb55",
     "jlink_device": "STM32WB55xx",
     "onboard_tools": [
       "stlink"


### PR DESCRIPTION
Board files declares `openocd_target": "stm32w55xx"` but there is no `scripts\target\stm32w55xx.cfg` in OpenOCD.

Should use the better suites *board* config file `st_nucleo_wb55.cfg` instead.

See [forum](https://community.platformio.org/t/cant-flash-getting-openocd-error-cant-find-target-stm32w55xx-cfg/28146).