### PR TITLE
add support for STM32F030Cx generic targets

### DIFF
--- a/boards/genericSTM32F030C6.json
+++ b/boards/genericSTM32F030C6.json
@@ -1,0 +1,38 @@
+{
+  "build": {
+    "core": "stm32",
+    "cpu": "cortex-m0",
+    "extra_flags": "-DSTM32F030x6 -DSTM32F0",
+    "f_cpu": "48000000L",
+    "mcu": "stm32f030c6t6",
+    "product_line": "STM32F030x6",
+    "variant": "STM32F0xx/F030C6T"
+  },
+  "debug": {
+    "jlink_device": "STM32F030C6",
+    "openocd_target": "stm32f0x",
+    "svd_path": "STM32F030.svd"
+  },
+  "frameworks": [
+    "arduino",
+    "cmsis",
+    "mbed",
+    "libopencm3"
+    "stm32cube",
+  ],
+  "name": "STM32F030C6 (4k RAM. 32k Flash)",
+  "upload": {
+    "maximum_ram_size": 4096,
+    "maximum_size": 32768,
+    "protocol": "stlink",
+    "protocols": [
+      "jlink",
+      "cmsis-dap",
+      "stlink",
+      "blackmagic",
+      "serial"
+    ]
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32f030c6.html",
+  "vendor": "Generic"
+}

--- a/boards/genericSTM32F030C8.json
+++ b/boards/genericSTM32F030C8.json
@@ -1,0 +1,38 @@
+{
+  "build": {
+    "core": "stm32",
+    "cpu": "cortex-m0",
+    "extra_flags": "-DSTM32F030x8 -DSTM32F0",
+    "f_cpu": "48000000L",
+    "mcu": "stm32f030c8t6",
+    "product_line": "STM32F030x8",
+    "variant": "STM32F0xx/F030C8T"
+  },
+  "debug": {
+    "jlink_device": "STM32F030C8",
+    "openocd_target": "stm32f0x",
+    "svd_path": "STM32F030.svd"
+  },
+  "frameworks": [
+    "arduino",
+    "cmsis",
+    "mbed",
+    "libopencm3"
+    "stm32cube",
+  ],
+  "name": "STM32F030C8 (8k RAM. 64k Flash)",
+  "upload": {
+    "maximum_ram_size": 8192,
+    "maximum_size": 65536,
+    "protocol": "stlink",
+    "protocols": [
+      "jlink",
+      "cmsis-dap",
+      "stlink",
+      "blackmagic",
+      "serial"
+    ]
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32f030c8.html",
+  "vendor": "Generic"
+}

--- a/boards/genericSTM32F030CC.json
+++ b/boards/genericSTM32F030CC.json
@@ -1,0 +1,38 @@
+{
+  "build": {
+    "core": "stm32",
+    "cpu": "cortex-m0",
+    "extra_flags": "-DSTM32F030xC -DSTM32F0",
+    "f_cpu": "48000000L",
+    "mcu": "stm32f030cct6",
+    "product_line": "STM32F030xC",
+    "variant": "STM32F0xx/F030CCT"
+  },
+  "debug": {
+    "jlink_device": "STM32F030CC",
+    "openocd_target": "stm32f0x",
+    "svd_path": "STM32F030.svd"
+  },
+  "frameworks": [
+    "arduino",
+    "cmsis",
+    "mbed",
+    "libopencm3"
+    "stm32cube",
+  ],
+  "name": "STM32F030CC (32k RAM. 256k Flash)",
+  "upload": {
+    "maximum_ram_size": 32768,
+    "maximum_size": 262144,
+    "protocol": "stlink",
+    "protocols": [
+      "jlink",
+      "cmsis-dap",
+      "stlink",
+      "blackmagic",
+      "serial"
+    ]
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32f030cc.html",
+  "vendor": "Generic"
+}


### PR DESCRIPTION
Support `STM32GF030C6`, `STM32GF030C8` and `STM32GF030CC`