### PR TITLE
Request to add board manifest for generic STM32G030C8

### DIFF
--- a/boards/genericSTM32G030C8.json
+++ b/boards/genericSTM32G030C8.json
@@ -1,0 +1,40 @@
+{
+  "build": {
+    "core": "stm32",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DSTM32G0xx -DSTM32G030xx",
+    "f_cpu": "64000000L",
+    "mcu": "stm32g030c8t6",
+    "product_line": "STM32G030xx",
+    "variant": "STM32G0xx/G030C(6-8)T"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32G030C8",
+    "openocd_target": "stm32g0x",
+    "svd_path": "STM32G030.svd"
+  },
+  "frameworks": [
+    "arduino",
+    "cmsis",
+    "libopencm3",
+    "stm32cube"
+  ],
+  "name": "STM32G030C8 (8k RAM. 64k Flash)",
+  "upload": {
+    "maximum_ram_size": 8192,
+    "maximum_size": 65536,
+    "protocol": "serial",
+    "protocols": [
+      "blackmagic",
+      "dfu",
+      "jlink",
+      "serial",
+      "stlink"
+    ]
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32g030c8.html",
+  "vendor": "Generic"
+}


### PR DESCRIPTION
Hi,

I'm making this PR because I had to do a little bit of research to configure a certain microcontroller to work with the platformio framework, and I thought that maybe this could help someone.

Currently I'm working with the STM32G030C8 microcontroller, it seems that it's still quite new in the market and that because of this there are no well known development boards for it.

I knew that there were different manifest files to support generic STM32 microcontrollers but unfortunatelly mine wasn't on that list, so I had to make a custom embedded board manifest file as it's explained [here](https://docs.platformio.org/en/latest/platforms/creating_board.html).

To make this board manifest json file as reusable as I could, I tried to make it as similar to the rest of generic manifest files such as the following ones:

- genericSTM32F103C4.json
- genericSTM32F103C6.json
- genericSTM32F103C8.json
- etc...

Regarding the testing of this manifest file, I've tested compiling different "hello world" programs using all frameworks listed ("arduino", "cmsis", "libopencm3", "stm32cube") and they worked flawlessly.

In my current application I can only communicate with the microcontroller using stlink, that's the only upload/debug protocol that I could test, and again, it works fine.

Even though this was the only upload/debug protocol that I could test, I listed all the standard supported protocols in the STM32 family as they were listed in the others manifest files, I don't see any reason why they shouldn't work.

Thanks for reading.