### PR TITLE
Enable SPL for STM32F1

### DIFF
--- a/boards/afroflight_f103cb.json
+++ b/boards/afroflight_f103cb.json
@@ -20,7 +20,8 @@
     "arduino",
     "cmsis",
     "stm32cube",
-    "libopencm3"
+    "libopencm3",
+    "spl"
   ],
   "name": "AfroFlight Rev5 (8MHz)",
   "upload": {

--- a/boards/blackpill_f103c8.json
+++ b/boards/blackpill_f103c8.json
@@ -40,6 +40,7 @@
     "arduino",
     "cmsis",
     "libopencm3",
+    "spl",
     "stm32cube",
     "zephyr"
   ],

--- a/boards/blackpill_f103c8_128.json
+++ b/boards/blackpill_f103c8_128.json
@@ -40,6 +40,7 @@
     "arduino",
     "cmsis",
     "libopencm3",
+    "spl",
     "stm32cube",
     "zephyr"
   ],

--- a/boards/bluepill_f103c6.json
+++ b/boards/bluepill_f103c6.json
@@ -34,7 +34,8 @@
     "arduino",
     "cmsis",
     "stm32cube",
-    "libopencm3"
+    "libopencm3",
+    "spl"
   ],
   "name": "BluePill F103C6",
   "upload": {

--- a/boards/bluepill_f103c8.json
+++ b/boards/bluepill_f103c8.json
@@ -41,6 +41,7 @@
     "mbed",
     "cmsis",
     "libopencm3",
+    "spl",
     "stm32cube",
     "zephyr",
     "spl"

--- a/boards/bluepill_f103c8.json
+++ b/boards/bluepill_f103c8.json
@@ -42,7 +42,8 @@
     "cmsis",
     "libopencm3",
     "stm32cube",
-    "zephyr"
+    "zephyr",
+    "spl"
   ],
   "name": "BluePill F103C8",
   "upload": {

--- a/boards/bluepill_f103c8_128k.json
+++ b/boards/bluepill_f103c8_128k.json
@@ -40,6 +40,7 @@
     "arduino",
     "cmsis",
     "libopencm3",
+    "spl",
     "stm32cube",
     "zephyr"
   ],

--- a/boards/disco_f100rb.json
+++ b/boards/disco_f100rb.json
@@ -23,6 +23,7 @@
     "cmsis",
     "mbed",
     "libopencm3",
+    "spl",
     "stm32cube"
   ],
   "name": "ST STM32VLDISCOVERY",

--- a/boards/eval_f107vc.json
+++ b/boards/eval_f107vc.json
@@ -18,6 +18,7 @@
     "cmsis",
     "stm32cube",
     "libopencm3",
+    "spl",
     "zephyr"
   ],
   "name": "STM3210C-EVAL",

--- a/boards/genericSTM32F103C4.json
+++ b/boards/genericSTM32F103C4.json
@@ -17,7 +17,8 @@
     "arduino",
     "cmsis",
     "stm32cube",
-    "libopencm3"
+    "libopencm3",
+    "spl"
   ],
   "name": "STM32F103C4 (6k RAM. 16k Flash)",
   "upload": {

--- a/boards/genericSTM32F103C6.json
+++ b/boards/genericSTM32F103C6.json
@@ -17,7 +17,8 @@
     "arduino",
     "cmsis",
     "stm32cube",
-    "libopencm3"
+    "libopencm3",
+    "spl"
   ],
   "name": "STM32F103C6 (10k RAM. 32k Flash)",
   "upload": {

--- a/boards/genericSTM32F103C8.json
+++ b/boards/genericSTM32F103C8.json
@@ -28,6 +28,7 @@
     "cmsis",
     "mbed",
     "libopencm3",
+    "spl",
     "stm32cube"
   ],
   "name": "STM32F103C8 (20k RAM. 64k Flash)",

--- a/boards/genericSTM32F103CB.json
+++ b/boards/genericSTM32F103CB.json
@@ -27,6 +27,7 @@
     "arduino",
     "cmsis",
     "libopencm3",
+    "spl",
     "stm32cube"
   ],
   "name": "STM32F103CB (20k RAM. 128k Flash)",

--- a/boards/genericSTM32F103R4.json
+++ b/boards/genericSTM32F103R4.json
@@ -17,7 +17,8 @@
     "arduino",
     "cmsis",
     "stm32cube",
-    "libopencm3"
+    "libopencm3",
+    "spl"
   ],
   "name": "STM32F103R4 (6k RAM. 16k Flash)",
   "upload": {

--- a/boards/genericSTM32F103R6.json
+++ b/boards/genericSTM32F103R6.json
@@ -17,7 +17,8 @@
     "arduino",
     "cmsis",
     "stm32cube",
-    "libopencm3"
+    "libopencm3",
+    "spl"
   ],
   "name": "STM32F103R6 (10k RAM. 32k Flash)",
   "upload": {

--- a/boards/genericSTM32F103R8.json
+++ b/boards/genericSTM32F103R8.json
@@ -27,6 +27,7 @@
     "arduino",
     "cmsis",
     "libopencm3",
+    "spl",
     "stm32cube"
   ],
   "name": "STM32F103R8 (20k RAM. 64 Flash)",

--- a/boards/genericSTM32F103RB.json
+++ b/boards/genericSTM32F103RB.json
@@ -28,6 +28,7 @@
     "cmsis",
     "mbed",
     "libopencm3",
+    "spl",
     "stm32cube"
   ],
   "name": "STM32F103RB (20k RAM. 128k Flash)",

--- a/boards/genericSTM32F103RC.json
+++ b/boards/genericSTM32F103RC.json
@@ -27,6 +27,7 @@
     "arduino",
     "cmsis",
     "libopencm3",
+    "spl",
     "stm32cube"
   ],
   "name": "STM32F103RC (48k RAM. 256k Flash)",

--- a/boards/genericSTM32F103RD.json
+++ b/boards/genericSTM32F103RD.json
@@ -17,7 +17,8 @@
     "arduino",
     "cmsis",
     "stm32cube",
-    "libopencm3"
+    "libopencm3",
+    "spl"
   ],
   "name": "STM32F103RD (64k RAM. 384k Flash)",
   "upload": {

--- a/boards/genericSTM32F103RE.json
+++ b/boards/genericSTM32F103RE.json
@@ -27,6 +27,7 @@
     "arduino",
     "cmsis",
     "libopencm3",
+    "spl",
     "stm32cube"
   ],
   "name": "STM32F103RE (64k RAM. 512k Flash)",

--- a/boards/genericSTM32F103RF.json
+++ b/boards/genericSTM32F103RF.json
@@ -17,7 +17,8 @@
     "arduino",
     "cmsis",
     "stm32cube",
-    "libopencm3"
+    "libopencm3",
+    "spl"
   ],
   "name": "STM32F103RF (96k RAM. 768k Flash)",
   "upload": {

--- a/boards/genericSTM32F103RG.json
+++ b/boards/genericSTM32F103RG.json
@@ -17,7 +17,8 @@
     "arduino",
     "cmsis",
     "stm32cube",
-    "libopencm3"
+    "libopencm3",
+    "spl"
   ],
   "name": "STM32F103RG (96k RAM. 1024k Flash)",
   "upload": {

--- a/boards/genericSTM32F103T4.json
+++ b/boards/genericSTM32F103T4.json
@@ -17,7 +17,8 @@
     "arduino",
     "cmsis",
     "stm32cube",
-    "libopencm3"
+    "libopencm3",
+    "spl"
   ],
   "name": "STM32F103T4 (6k RAM. 16k Flash)",
   "upload": {

--- a/boards/genericSTM32F103T6.json
+++ b/boards/genericSTM32F103T6.json
@@ -17,7 +17,8 @@
     "arduino",
     "cmsis",
     "stm32cube",
-    "libopencm3"
+    "libopencm3",
+    "spl"
   ],
   "name": "STM32F103T6 (10k RAM. 32k Flash)",
   "upload": {

--- a/boards/genericSTM32F103T8.json
+++ b/boards/genericSTM32F103T8.json
@@ -27,6 +27,7 @@
     "arduino",
     "cmsis",
     "libopencm3",
+    "spl",
     "stm32cube"
   ],
   "name": "STM32F103T8 (20k RAM. 64k Flash)",

--- a/boards/genericSTM32F103TB.json
+++ b/boards/genericSTM32F103TB.json
@@ -27,6 +27,7 @@
     "arduino",
     "cmsis",
     "libopencm3",
+    "spl",
     "stm32cube"
   ],
   "name": "STM32F103TB (20k RAM. 128k Flash)",

--- a/boards/genericSTM32F103V8.json
+++ b/boards/genericSTM32F103V8.json
@@ -17,7 +17,8 @@
     "arduino",
     "cmsis",
     "stm32cube",
-    "libopencm3"
+    "libopencm3",
+    "spl"
   ],
   "name": "STM32F103V8 (20k RAM. 64k Flash)",
   "upload": {

--- a/boards/genericSTM32F103VB.json
+++ b/boards/genericSTM32F103VB.json
@@ -27,6 +27,7 @@
     "arduino",
     "cmsis",
     "libopencm3",
+    "spl",
     "stm32cube"
   ],
   "name": "STM32F103VB (20k RAM. 128k Flash)",

--- a/boards/genericSTM32F103VC.json
+++ b/boards/genericSTM32F103VC.json
@@ -27,6 +27,7 @@
     "arduino",
     "cmsis",
     "libopencm3",
+    "spl",
     "stm32cube"
   ],
   "name": "STM32F103VC (48k RAM. 256k Flash)",

--- a/boards/genericSTM32F103VD.json
+++ b/boards/genericSTM32F103VD.json
@@ -27,6 +27,7 @@
     "arduino",
     "cmsis",
     "libopencm3",
+    "spl",
     "stm32cube"
   ],
   "name": "STM32F103VD (64k RAM. 384k Flash)",

--- a/boards/genericSTM32F103VE.json
+++ b/boards/genericSTM32F103VE.json
@@ -27,6 +27,7 @@
     "arduino",
     "cmsis",
     "libopencm3",
+    "spl",
     "stm32cube"
   ],
   "name": "STM32F103VE (64k RAM. 512k Flash)",

--- a/boards/genericSTM32F103VF.json
+++ b/boards/genericSTM32F103VF.json
@@ -17,7 +17,8 @@
     "arduino",
     "cmsis",
     "stm32cube",
-    "libopencm3"
+    "libopencm3",
+    "spl"
   ],
   "name": "STM32F103VF (96k RAM. 768k Flash)",
   "upload": {

--- a/boards/genericSTM32F103VG.json
+++ b/boards/genericSTM32F103VG.json
@@ -17,7 +17,8 @@
     "arduino",
     "cmsis",
     "stm32cube",
-    "libopencm3"
+    "libopencm3",
+    "spl"
   ],
   "name": "STM32F103VG (96k RAM. 1024k Flash)",
   "upload": {

--- a/boards/genericSTM32F103ZC.json
+++ b/boards/genericSTM32F103ZC.json
@@ -27,6 +27,7 @@
     "arduino",
     "cmsis",
     "libopencm3",
+    "spl",
     "stm32cube"
   ],
   "name": "STM32F103ZC (48k RAM. 256k Flash)",

--- a/boards/genericSTM32F103ZD.json
+++ b/boards/genericSTM32F103ZD.json
@@ -27,6 +27,7 @@
     "arduino",
     "cmsis",
     "libopencm3",
+    "spl",
     "stm32cube"
   ],
   "name": "STM32F103ZD (64k RAM. 384k Flash)",

--- a/boards/genericSTM32F103ZE.json
+++ b/boards/genericSTM32F103ZE.json
@@ -27,6 +27,7 @@
     "arduino",
     "cmsis",
     "libopencm3",
+    "spl",
     "stm32cube"
   ],
   "name": "STM32F103ZE (64k RAM. 512k Flash)",

--- a/boards/genericSTM32F103ZF.json
+++ b/boards/genericSTM32F103ZF.json
@@ -17,7 +17,8 @@
     "arduino",
     "cmsis",
     "stm32cube",
-    "libopencm3"
+    "libopencm3",
+    "spl"
   ],
   "name": "STM32F103ZF (96k RAM. 768k Flash)",
   "upload": {

--- a/boards/genericSTM32F103ZG.json
+++ b/boards/genericSTM32F103ZG.json
@@ -17,7 +17,8 @@
     "arduino",
     "cmsis",
     "stm32cube",
-    "libopencm3"
+    "libopencm3",
+    "spl"
   ],
   "name": "STM32F103ZG (96k RAM. 1024k Flash)",
   "upload": {

--- a/boards/hy_tinystm103tb.json
+++ b/boards/hy_tinystm103tb.json
@@ -27,7 +27,8 @@
     "arduino",
     "cmsis",
     "stm32cube",
-    "libopencm3"
+    "libopencm3",
+    "spl"
   ],
   "name": "Tiny STM103T",
   "upload": {

--- a/boards/malyanm200_f070cb.json
+++ b/boards/malyanm200_f070cb.json
@@ -23,7 +23,8 @@
     "arduino",
     "cmsis",
     "stm32cube",
-    "libopencm3"
+    "libopencm3",
+    "spl"
   ],
   "name": "M200 V2",
   "upload": {

--- a/boards/malyanm200_f103cb.json
+++ b/boards/malyanm200_f103cb.json
@@ -30,7 +30,8 @@
     "arduino",
     "cmsis",
     "stm32cube",
-    "libopencm3"
+    "libopencm3",
+    "spl"
   ],
   "name": "Malyan M200 V1",
   "upload": {

--- a/boards/maple.json
+++ b/boards/maple.json
@@ -27,6 +27,7 @@
     "arduino",
     "cmsis",
     "libopencm3",
+    "spl",
     "stm32cube"
   ],
   "name": "Maple",

--- a/boards/maple_mini_b20.json
+++ b/boards/maple_mini_b20.json
@@ -27,6 +27,7 @@
     "arduino",
     "cmsis",
     "libopencm3",
+    "spl",
     "stm32cube"
   ],
   "name": "Maple Mini Bootloader 2.0",

--- a/boards/maple_mini_origin.json
+++ b/boards/maple_mini_origin.json
@@ -30,6 +30,7 @@
     "arduino",
     "cmsis",
     "libopencm3",
+    "spl",
     "stm32cube"
   ],
   "name": "Maple Mini Original",

--- a/boards/maple_ret6.json
+++ b/boards/maple_ret6.json
@@ -27,6 +27,7 @@
     "arduino",
     "cmsis",
     "libopencm3",
+    "spl",
     "stm32cube"
   ],
   "name": "Maple (RET6)",

--- a/boards/microduino32_flash.json
+++ b/boards/microduino32_flash.json
@@ -27,7 +27,8 @@
     "arduino",
     "cmsis",
     "stm32cube",
-    "libopencm3"
+    "libopencm3",
+    "spl"
   ],
   "name": "Microduino Core STM32 to Flash",
   "upload": {

--- a/boards/nucleo_f103rb.json
+++ b/boards/nucleo_f103rb.json
@@ -25,6 +25,7 @@
     "cmsis",
     "mbed",
     "libopencm3",
+    "spl",
     "stm32cube",
     "zephyr"
   ],

--- a/boards/olimex_f103.json
+++ b/boards/olimex_f103.json
@@ -21,6 +21,7 @@
     "cmsis",
     "mbed",
     "libopencm3",
+    "spl",
     "stm32cube"
   ],
   "name": "Olimex STM32-H103",

--- a/boards/olimexino.json
+++ b/boards/olimexino.json
@@ -21,6 +21,7 @@
     "cmsis",
     "mbed",
     "libopencm3",
+    "spl",
     "stm32cube",
     "zephyr"
   ],

--- a/boards/storm32_v1_31_rc.json
+++ b/boards/storm32_v1_31_rc.json
@@ -20,6 +20,7 @@
     "arduino",
     "cmsis",
     "libopencm3",
+    "spl",
     "stm32cube"
   ],
   "name": "STorM32 BGC v1.31 RC",

--- a/boards/vccgnd_f103zet6.json
+++ b/boards/vccgnd_f103zet6.json
@@ -17,7 +17,8 @@
     "arduino",
     "cmsis",
     "stm32cube",
-    "libopencm3"
+    "libopencm3",
+    "spl"
   ],
   "name": "VCCGND F103ZET6 Mini",
   "upload": {

--- a/boards/waveshare_open103z.json
+++ b/boards/waveshare_open103z.json
@@ -17,6 +17,7 @@
     "arduino",
     "cmsis",
     "libopencm3",
+    "spl",
     "stm32cube"
   ],
   "name": "Waveshare Open103Z",

--- a/examples/spl-blink/platformio.ini
+++ b/examples/spl-blink/platformio.ini
@@ -21,3 +21,8 @@ board = disco_l152rb
 platform = ststm32
 framework = spl
 board = disco_f303vc
+
+[env:bluepill_f103c8]
+platform = ststm32
+framework = spl
+board = bluepill_f103c8

--- a/examples/spl-blink/src/main.c
+++ b/examples/spl-blink/src/main.c
@@ -1,4 +1,10 @@
-#ifdef STM32L1
+#ifdef STM32F1
+	#include <stm32f10x_gpio.h>
+	#include <stm32f10x_rcc.h>
+	#define LEDPORT (GPIOC)
+	#define LEDPIN (GPIO_Pin_13)
+	#define ENABLE_GPIO_CLOCK (RCC_APB2PeriphClockCmd(RCC_APB2Periph_GPIOC, ENABLE))
+#elif STM32L1
 	#include <stm32l1xx_gpio.h>
 	#include <stm32l1xx_rcc.h>
 	#define LEDPORT (GPIOB)
@@ -16,20 +22,37 @@
 	#define LEDPORT (GPIOD)
 	#define LEDPIN (GPIO_Pin_12)
 	#define ENABLE_GPIO_CLOCK (RCC_AHB1PeriphClockCmd(RCC_AHB1Periph_GPIOD, ENABLE))
+#else
+	#error "Please define one of the macros STM32F1, STM32L1, STM32F3 or STM32F4."
 #endif
 
-/* timing is not guaranteed :) */
-void simple_delay(uint32_t us)
-{
-	/* simple delay loop */
-	while (us--) {
-		asm volatile ("nop");
+/* wanted blink time in milliseconds */
+#define DELAY_TIME_MILLIS 1000
+
+/* variable keeps track of timing delay */
+static __IO uint32_t TimingDelay;
+
+void Delay(__IO uint32_t nTime) {
+	TimingDelay = nTime;
+	/* wait until variable is decreased to 0 through ISR calls */
+	while (TimingDelay != 0);
+}
+
+void TimingDelay_Decrement(void) {
+	/* called in systick ISR */
+	if (TimingDelay != 0x00) {
+		TimingDelay--;
 	}
 }
 
 /* system entry point */
 int main(void)
 {
+	//setup SysTick for 1 millisecond interrupts
+	if (SysTick_Config(SystemCoreClock / 1000)) {
+		/* Capture error */
+		while (1);
+	}
 	/* gpio init struct */
 	GPIO_InitTypeDef gpio;
 	/* reset rcc */
@@ -38,10 +61,15 @@ int main(void)
 	ENABLE_GPIO_CLOCK;
 	/* use LED pin */
 	gpio.GPIO_Pin = LEDPIN;
+	/* set pin to push-pull output depending on the SPL variant */
+#if STM32F1
+	gpio.GPIO_Mode = GPIO_Mode_Out_PP;
+#else
 	/* mode: output */
 	gpio.GPIO_Mode = GPIO_Mode_OUT;
 	/* output type: push-pull */
 	gpio.GPIO_OType = GPIO_OType_PP;
+#endif
 	/* apply configuration */
 	GPIO_Init(LEDPORT, &gpio);
 	/* main program loop */
@@ -49,13 +77,18 @@ int main(void)
 		/* set led on */
 		GPIO_SetBits(LEDPORT, LEDPIN);
 		/* delay */
-		simple_delay(100000);
+		Delay(DELAY_TIME_MILLIS);
 		/* clear led */
 		GPIO_ResetBits(LEDPORT, LEDPIN);
 		/* delay */
-		simple_delay(100000);
+		Delay(DELAY_TIME_MILLIS);
 	}
 
 	/* never reached */
 	return 0;
+}
+
+/* SysTick interrupt every millisecond */
+void SysTick_Handler(void) {
+	TimingDelay_Decrement();
 }

--- a/platform.json
+++ b/platform.json
@@ -180,7 +180,7 @@
       "type": "framework",
       "optional": true,
       "owner": "platformio",
-      "version": "~2.10201.0"
+      "version": "https://github.com/maxgerhardt/pio-framework-spl-stm32.git"
     },
     "framework-libopencm3": {
       "type": "framework",


### PR DESCRIPTION
Enables Simple Peripheral LIbrary (SPL) framework support for STM32F1.

Uses the most recent SPL F1 package version 3.6.0 from [here](https://www.st.com/content/my_st_com/en/products/embedded-software/mcu-mpu-embedded-software/stm32-embedded-software/stm32-standard-peripheral-libraries/stsw-stm32054.license=1553116408827.product=STSW-STM32054.version=3.5.0.html).

The SPL framework needs the boards to have an identifying macro like `STM32F10X_MD` for "medium density" device. Instead of computing and adding this to ~50 board files, a on-the-fly identification is made based on chip name and flash size, like the reference manual wants it.

Rewrites the spl-blink example to use the SysTick for delay and adds the F1 code to it.