### PR TITLE
added mbed frame work to portenta h7 board definitions

### DIFF
--- a/boards/portenta_h7_m4.json
+++ b/boards/portenta_h7_m4.json
@@ -27,7 +27,8 @@
     "openocd_target": "stm32h7x_dual_bank"
   },
   "frameworks": [
-    "arduino"
+    "arduino",
+    "mbed"
   ],
   "name": "Arduino Portenta H7 (M4 core)",
   "upload": {

--- a/boards/portenta_h7_m7.json
+++ b/boards/portenta_h7_m7.json
@@ -27,7 +27,8 @@
     "openocd_target": "stm32h7x_dual_bank"
   },
   "frameworks": [
-    "arduino"
+    "arduino",
+    "mbed"
   ],
   "name": "Arduino Portenta H7 (M7 core)",
   "upload": {


### PR DESCRIPTION
I have been using the mbed framework with the Arduino Portenta board directly through an edit of the board definition file.
As mbed is used anyways for the arduino framework through [ArduinoCore-mbed](https://github.com/arduino/ArduinoCore-mbed) there are not compatability issues with also allowing the mbed framework directly.