### PR TITLE
Adding a platformio generic board definition for STM32H750VBT6.

### DIFF
--- a/boards/genericSTM32H750VBT6.json
+++ b/boards/genericSTM32H750VBT6.json
@@ -1,0 +1,37 @@
+{
+  "build": {
+    "core": "stm32",
+    "cpu": "cortex-m7",
+    "extra_flags": "-DSTM32H7xx -DSTM32H750xx",
+    "f_cpu": "480000000L",
+    "mcu": "stm32h750vbt6",
+    "product_line": "STM32H750xx",
+    "variant": "STM32H7xx/H742V(G-I)(H-T)_H743V(G-I)(H-T)_H750VBT_H753VI(H-T)"
+  },
+  "debug": {
+    "jlink_device": "STM32H750VB",
+    "openocd_target": "stm32h7x",
+    "svd_path": "STM32H750.svd"
+  },
+  "frameworks": [
+    "arduino",
+    "cmsis",
+    "stm32cube",
+    "libopencm3"
+  ],
+  "name": "STM32H750VBT6 (1024k RAM. 128k Flash)",
+  "upload": {
+    "maximum_ram_size": 1048576,
+    "maximum_size": 131072,
+    "protocol": "serial",
+    "protocols": [
+      "blackmagic",
+      "dfu",
+      "jlink",
+      "serial",
+      "stlink"
+    ]
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32h750vb.html",
+  "vendor": "Generic"
+}


### PR DESCRIPTION
Adding a platformio board definition for generic STM32H750VBT6.  

I tested it with build/run/debug, using stlink V2.