### PR TITLE
add genericSTM32G431CB board file

### DIFF
--- a/boards/genericSTM32G431CB.json
+++ b/boards/genericSTM32G431CB.json
@@ -1,0 +1,46 @@
+{
+  "build": {
+    "core": "stm32",
+    "cpu": "cortex-m4",
+    "extra_flags": "-DSTM32G4xx -DSTM32G431xx",
+    "f_cpu": "170000000L",
+    "mcu": "stm32g431cbu6",
+    "product_line": "STM32G431xx",
+    "variant": "STM32G4xx/G431C(6-8-B)U_G441CBU"
+  },
+  "connectivity": [
+    "can"
+  ],
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32G431CB",
+    "onboard_tools": [
+      "stlink"
+    ],
+    "openocd_target": "stm32g4x",
+    "svd_path": "STM32G431xx.svd"
+  },
+  "frameworks": [
+    "arduino",
+    "cmsis",
+    "libopencm3",
+    "stm32cube"
+  ],
+  "name": "STM32G431CB",
+  "upload": {
+    "maximum_ram_size": 32768,
+    "maximum_size": 131072,
+    "protocol": "stlink",
+    "protocols": [
+      "stlink",
+      "jlink",
+      "cmsis-dap",
+      "blackmagic",
+      "mbed"
+    ]
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32g431cb.html",
+  "vendor": "ST"
+}


### PR DESCRIPTION
This chip is supported already, but for some reason, only in the board for B-G431B-ESC1 which uses a custom PinMap (no generic file available).
This is the config for the bare chip, using the default PinMap.