### PR TITLE
Add Mbed support for NUCELO_H723ZG.

### DIFF
--- a/boards/nucleo_h723zg.json
+++ b/boards/nucleo_h723zg.json
@@ -26,6 +26,7 @@
   "frameworks": [
     "arduino",
     "stm32cube",
+    "mbed",
     "zephyr"
   ],
   "name": "ST Nucleo H723ZG",


### PR DESCRIPTION
Mbed has added support for NUCELO_H723ZG with version 6.17.0.
This has already been added to platformio with version 16.1.0 as default Mbed version.
Make this Mbed support for this board also available in platformio.