### PR TITLE
Support arduino for nucleo_h753zi

### DIFF
--- a/boards/nucleo_h753zi.json
+++ b/boards/nucleo_h753zi.json
@@ -5,7 +5,8 @@
     "extra_flags": "-DSTM32H7xx -DSTM32H753xx",
     "f_cpu": "400000000L",
     "mcu": "stm32h753zit6",
-    "product_line": "STM32H753xx"
+    "product_line": "STM32H753xx",
+    "variant": "STM32H7xx/H742Z(G-I)T_H743Z(G-I)T_H747A(G-I)I_H747I(G-I)T_H750ZBT_H753ZIT_H757AII_H757IIT"
   },
   "connectivity": [
     "can",
@@ -23,6 +24,7 @@
     "svd_path": "STM32H753.svd"
   },
   "frameworks": [
+    "arduino",
     "cmsis",
     "stm32cube",
     "zephyr"

--- a/boards/nucleo_h753zi.json
+++ b/boards/nucleo_h753zi.json
@@ -31,7 +31,7 @@
   ],
   "name": "ST Nucleo H753ZI",
   "upload": {
-    "maximum_ram_size": 884736,
+    "maximum_ram_size": 524288,
     "maximum_size": 2097152,
     "protocol": "stlink",
     "protocols": [


### PR DESCRIPTION
nucleo_h753zi is supported from arduino core stm32 2.7.0  so I want you to support it.
https://github.com/stm32duino/Arduino_Core_STM32/commit/0fb3eff98c4d64c57acefb2ebee29fd0911b40f2