### PR TITLE
Fix ST STM32G0316-DISCO flash size

### DIFF
--- a/boards/disco_g031j6.json
+++ b/boards/disco_g031j6.json
@@ -25,7 +25,7 @@
   "name": "ST STM32G0316-DISCO",
   "upload": {
     "maximum_ram_size": 8192,
-    "maximum_size": 131072,
+    "maximum_size": 32768,
     "protocol": "mbed",
     "protocols": [
       "blackmagic",


### PR DESCRIPTION
STM32G0316-DISCO (STM32G031J6) has only 32kb of flash

References:
https://www.st.com/en/evaluation-tools/stm32g0316-disco.html
https://www.st.com/en/microcontrollers-microprocessors/stm32g031j6.html