### PR TITLE
Add Arduino core support to Nucleo-F446ZE board

### DIFF
--- a/boards/nucleo_f446ze.json
+++ b/boards/nucleo_f446ze.json
@@ -4,7 +4,8 @@
     "extra_flags": "-DSTM32F4 -DSTM32F446xx",
     "f_cpu": "180000000L",
     "mcu": "stm32f446zet6",
-    "product_line": "STM32F446xx"
+    "product_line": "STM32F446xx",
+    "variant": "STM32F4XX/F446Z(C-E)(H-J-T)"
   },
   "connectivity": [
     "can"
@@ -22,6 +23,7 @@
     "svd_path": "STM32F446x.svd"
   },
   "frameworks": [
+    "arduino",
     "cmsis",
     "mbed",
     "stm32cube",


### PR DESCRIPTION
Added variant and Arduino framework to board file, per issue #772