### PR TITLE
add generic STM32G071RB

### DIFF
--- a/boards/genericSTM32G071RB.json
+++ b/boards/genericSTM32G071RB.json
@@ -11,13 +11,7 @@
     }
   },
   "debug": {
-    "default_tools": [
-      "stlink"
-    ],
     "jlink_device": "STM32G071RB",
-    "onboard_tools": [
-      "stlink"
-    ],
     "openocd_target": "stm32g0x",
     "svd_path": "STM32G071.svd"
   },

--- a/boards/genericSTM32G071RB.json
+++ b/boards/genericSTM32G071RB.json
@@ -1,0 +1,46 @@
+{
+  "build": {
+    "core": "stm32",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DSTM32G0 -DSTM32G0xx -DSTM32G071xx",
+    "f_cpu": "64000000L",
+    "mcu": "stm32g071rbt6",
+    "product_line": "STM32G071xx",
+    "zephyr": {
+       "variant": "STM32G0xx/G071R(6-8)T_G071RB(I-T)_G081RB(I-T)"
+    }
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32G071RB",
+    "onboard_tools": [
+      "stlink"
+    ],
+    "openocd_target": "stm32g0x",
+    "svd_path": "STM32G071.svd"
+  },
+  "frameworks": [
+    "arduino",
+    "cmsis",
+    "libopencm3",
+    "stm32cube",
+    "zephyr"
+  ],
+  "name": "STM32G071B (36k RAM, 128k Flash)",
+  "upload": {
+    "maximum_ram_size": 36864,
+    "maximum_size": 131072,
+    "protocol": "stlink",
+    "protocols": [
+      "stlink",
+      "jlink",
+      "cmsis-dap",
+      "blackmagic",
+      "mbed"
+    ]
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32g071rb.html",
+  "vendor": "ST"
+}


### PR DESCRIPTION
Add the definition for using the G071RB in a generic configuration (like my earlier pull request for G431, the definition for the chip on the discovery kit exists but not as a standalone part to use in other projects). 