### PR TITLE
mbed-os enable nucleo_u575zi_q

### DIFF
--- a/boards/nucleo_u575zi_q.json
+++ b/boards/nucleo_u575zi_q.json
@@ -25,7 +25,8 @@
     "openocd_target": "stm32u5x"
   },
   "frameworks": [
-    "arduino"
+    "arduino",
+    "mbed"
   ],
   "name": "ST Nucleo U575ZI-Q",
   "upload": {


### PR DESCRIPTION
This supports mbed-os per

https://github.com/ARMmbed/mbed-os/blob/mbed-os-6.17.0/targets/targets.json#L4772-L4783

Compilation tested with https://github.com/platformio/platform-ststm32/blob/develop/examples/mbed-rtos-blink-baremetal, working fine.

```
Compiling .pio\build\nucleo_u575zi_q\src\main.o
Generating LD script .pio\build\nucleo_u575zi_q\stm32u575xi.ld.link_script.ld
Linking .pio\build\nucleo_u575zi_q\firmware.elf
Checking size .pio\build\nucleo_u575zi_q\firmware.elf
Advanced Memory Usage is available via "PlatformIO Home > Project Inspect"
RAM:   [          ]   4.1% (used 10648 bytes from 262144 bytes)
Flash: [          ]   2.2% (used 45180 bytes from 2097152 bytes)
Building .pio\build\nucleo_u575zi_q\firmware.bin