### PR TITLE
Update electrosmith_daisy board config's variant

### DIFF
--- a/boards/electrosmith_daisy.json
+++ b/boards/electrosmith_daisy.json
@@ -12,7 +12,7 @@
     },
     "mcu": "stm32h750ibk6",
     "product_line": "STM32H750xx",
-    "variant": "STM32H7xx/H742I(G-I)(K-T)_H743I(G-I)(K-T)_H750IB(K-T)_H753II(K-T)"
+    "variant": "STM32H7xx/H742I(G-I)K_H743I(G-I)K_H750IBK_H753IIK"
   },
   "connectivity": [
     "can"


### PR DESCRIPTION
Change the `variant` setting for the electrosmith daisy seed. 

without this change, I see 
```
Error 1: fatal error: variant_DAISY_SEED.h: No such file or directory
```

when trying to build my project w/ daisyduino and platformio. On my machine, `variant_DAISY_SEED.h` is in `STM32H7xx/H742I(G-I)K_H743I(G-I)K_H750IBK_H753IIK` , *not* `STM32H7xx/H742I(G-I)(K-T)_H743I(G-I)(K-T)_H750IB(K-T)_H753II(K-T)`.

I'm new to platformio so I'm not familiar with the implications of this change, but it now seems to be working as expected on my machine.