### PR TITLE
Add Blues Cygnet board

### DIFF
--- a/boards/blues_cygnet.json
+++ b/boards/blues_cygnet.json
@@ -1,0 +1,46 @@
+{
+    "build": {
+      "cpu": "cortex-m4",
+      "extra_flags": "-DSTM32L4 -DSTM32L433xx",
+      "f_cpu": "80000000L",
+      "framework_extra_flags": {
+        "arduino": "-DCUSTOM_PERIPHERAL_PINS -DARDUINO_CYGNET -DPIO_FRAMEWORK_ARDUINO_ENABLE_CDC"
+      },
+      "mcu": "stm32l433cct6",
+      "product_line": "STM32L433xx",
+      "variant": "STM32L4xx/L433C(B-C)(T-U)_L443CC(T-U)"
+    },
+    "connectivity": [
+      "can"
+    ],
+    "debug": {
+      "default_tools": [
+        "stlink"
+      ],
+      "jlink_device": "STM32L433CC",
+      "openocd_target": "stm32l4x",
+      "svd_path": "STM32L4x3.svd"
+    },
+    "frameworks": [
+      "arduino",
+      "cmsis",
+      "stm32cube",
+      "libopencm3"
+    ],
+    "name": "Cygnet",
+    "upload": {
+      "maximum_ram_size": 65536,
+      "maximum_size": 262144,
+      "protocol": "dfu",
+      "protocols": [
+        "dfu",
+        "jlink",
+        "cmsis-dap",
+        "stlink",
+        "blackmagic",
+        "mbed"
+      ]
+    },
+    "url": "https://blues.com/feather-mcu/",
+    "vendor": "Blues"
+  }

--- a/boards/blues_cygnet.json
+++ b/boards/blues_cygnet.json
@@ -27,7 +27,7 @@
       "stm32cube",
       "libopencm3"
     ],
-    "name": "Cygnet",
+    "name": "Blues Cygnet",
     "upload": {
       "maximum_ram_size": 65536,
       "maximum_size": 262144,

--- a/boards/blues_swan_r5.json
+++ b/boards/blues_swan_r5.json
@@ -1,8 +1,11 @@
 {
   "build": {
+    "arduino": {
+      "variant_h": "variant_SWAN_R5.h"
+    },
     "core": "stm32",
     "cpu": "cortex-m4",
-    "extra_flags": "-DSTM32L4 -DSTM32L4xx -DSTM32L4R5xx",
+    "extra_flags": "-DARDUINO_SWAN_R5 -DSTM32L4 -DSTM32L4xx -DSTM32L4R5xx",
     "f_cpu": "120000000L",
     "framework_extra_flags": {
       "arduino": "-DCUSTOM_PERIPHERAL_PINS"
@@ -23,7 +26,7 @@
     "arduino",
     "stm32cube"
   ],
-  "name": "Swan R5",
+  "name": "Blues Swan R5",
   "upload": {
     "maximum_ram_size": 655360,
     "maximum_size": 2097152,


### PR DESCRIPTION
Board see [here](https://blues.com/feather-mcu/), STM32Duino variant [here](https://github.com/stm32duino/Arduino_Core_STM32/blob/2.9.0/variants/STM32L4xx/L433C(B-C)(T-U)_L443CC(T-U)/variant_CYGNET.cpp). Closes https://github.com/platformio/platform-ststm32/issues/821

Tested by Blues employees.

* we already have `bw_swan_r5.json`, "BluesWireless" seems to be the old name though? Now it's just "Blues"? (I named this file `blues_cygnet.json`)
  * added copy of Blues Swan as `blues_swan_r5.json` 
* I activate the USB CDC by default because this board has no onboard USB-to-UART converter and can be flashed via USB by default, so users will expect `Serial` to also go via USB
* no on-board debugger probe: set DFU as default upload method for the same reason: Works by default with just USB cable
* No HWIDs, the code in `main.py` correctly selects `0x0483:0xDF11` (STM32 DFU) (Swan R5 also didn't set it)