### PR TITLE
Pull request to add new board definition for the Ebyte E77 dev board

### DIFF
--- a/boards/ebyte_e77_dev.json
+++ b/boards/ebyte_e77_dev.json
@@ -1,0 +1,38 @@
+{
+  "build": {
+    "arduino": {
+      "variant_h": "variant_generic.h"
+    },
+    "core": "stm32",
+    "cpu": "cortex-m4",
+    "extra_flags": "-DSTM32WL -DSTM32WLxx -DSTM32WLE5xx",
+    "f_cpu": "48000000L",
+    "framework_extra_flags": {
+      "arduino": "-DUSE_CM4_STARTUP_FILE -DARDUINO_GENERIC_WLE5CCUX"
+    },
+    "mcu": "stm32wle5cc",
+    "product_line": "STM32WLE5xx",
+    "variant": "STM32WLxx/WL54CCU_WL55CCU_WLE4C(8-B-C)U_WLE5C(8-B-C)U"
+  },
+  "debug": {
+    "jlink_device": "STM32WLE5CC",
+    "openocd_target": "stm32wlx",
+    "svd_path": "STM32WLE5_CM4.svd"
+  },
+  "frameworks": [
+    "arduino",
+    "zephyr"
+  ],
+  "name": "Ebyte E77 Dev Board",
+  "upload": {
+    "maximum_ram_size": 65536,
+    "maximum_size": 262144,
+    "protocol": "stlink",
+    "protocols": [
+      "stlink",
+      "jlink"
+    ]
+  },
+  "url": "https://www.cdebyte.com/products/E77-400MBL-01",
+  "vendor": "Ebyte"
+}


### PR DESCRIPTION
I have tested this to properly compile code to the Ebyte E77 dev board. This Ebyte E77 board is very similar to the lora_e5_dev board, which I modified for use with the Ebyte E77 dev board definition. The E77 uses the lower pin count FPGA chip instead of the FBGA chip that is used on the wio-e5.