### PR TITLE
Support for STM32F407IGT6 Arduino framework

### DIFF
--- a/boards/genericSTM32F407IGT6.json
+++ b/boards/genericSTM32F407IGT6.json
@@ -15,7 +15,8 @@
       ]
     ],
     "mcu": "stm32f407igt6",
-    "product_line": "STM32F407xx"
+    "product_line": "STM32F407xx",
+    "variant": "STM32F4xx/F407I(E-G)(H-T)_F417I(E-G)(H-T)"
   },
   "debug": {
     "default_tools": [
@@ -30,6 +31,7 @@
     "svd_path": "STM32F40x.svd"
   },
   "frameworks": [
+    "arduino",
     "cmsis",
     "stm32cube",
     "libopencm3"
@@ -37,7 +39,7 @@
   "name": "STM32F407IG (192k RAM. 1024k Flash)",
   "upload": {
     "disable_flushing": false,
-    "maximum_ram_size": 196608,
+    "maximum_ram_size": 131072,
     "maximum_size": 1048576,
     "protocol": "stlink",
     "protocols": [


### PR DESCRIPTION
**I have tested this change on my board, and it works.**

## Reason
Change max_ram_size from 192KB to 128KB so that the MCU does not crash on start. 

This is because the 192 KB includes 64KB CCMRAM.

The memory layout for stm32F4XX family is

MEMORY
{
    RAM (xrw)      : ORIGIN = 0x20000000, LENGTH = 128K
    CCMRAM (xrw)      : ORIGIN = 0x10000000, LENGTH = 64K
    FLASH (rx)      : ORIGIN = 0x8000000, LENGTH = 1024K
}

![image](https://github.com/user-attachments/assets/6c7315d9-067a-4305-8d6f-482151205340)

![image](https://github.com/user-attachments/assets/1e5028c9-b698-4db9-8157-f42512bbd218)
