### PR TITLE
Add support for NUCLEO-G491RE board

### DIFF
--- a/boards/nucleo_g491re.json
+++ b/boards/nucleo_g491re.json
@@ -1,0 +1,47 @@
+{
+  "build": {
+    "core": "stm32",
+    "cpu": "cortex-m4",
+    "extra_flags": "-DSTM32G4 -DSTM32G4xx -DSTM32G491xx",
+    "f_cpu": "170000000L",
+    "mcu": "stm32g491ret6",
+    "product_line": "STM32G491xx",
+    "variant": "STM32G491RE"
+  },
+  "connectivity": [
+    "can"
+  ],
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32G491RE",
+    "onboard_tools": [
+      "stlink"
+    ],
+    "openocd_target": "stm32g4x",
+    "svd_path": "STM32G491xx.svd"
+  },
+  "frameworks": [
+    "arduino",
+    "stm32cube",
+    "mbed",
+    "zephyr",
+    "libopencm3"
+  ],
+  "name": "Nucleo G491RE",
+  "upload": {
+    "maximum_ram_size": 114688,
+    "maximum_size": 524288,
+    "protocol": "stlink",
+    "protocols": [
+      "stlink",
+      "jlink",
+      "cmsis-dap",
+      "blackmagic",
+      "mbed"
+    ]
+  },
+  "url": "https://www.st.com/en/evaluation-tools/nucleo-g491re.html",
+  "vendor": "ST"
+}


### PR DESCRIPTION
This PR adds support for the *NUCLEO-G491RE* development board to the PlatformIO `ststm32` platform.

- Based on the existing *NUCLEO-G474RE* configuration, as both boards share a similar architecture.
- A new board JSON file `nucleo_g491re.json` has been added under `boards/`.
- Tested on actual *NUCLEO-G491RE* hardware to ensure correct operation (flashing, debugging, basic functionality).