### PR TITLE
Zephyr support for the nucleo_g070rb

### DIFF
--- a/boards/nucleo_g070rb.json
+++ b/boards/nucleo_g070rb.json
@@ -26,7 +26,8 @@
     "arduino",
     "cmsis",
     "libopencm3",
-    "stm32cube"
+    "stm32cube",
+    "zephyr"
   ],
   "name": "Nucleo G070RB",
   "upload": {


### PR DESCRIPTION
According to zephyr support for the nucleo_g070rb is supported but is not in the configuration. See zephyr documentation [here](https://docs.zephyrproject.org/latest/boards/st/nucleo_g070rb/doc/index.html)

Changes made:
Zephyr added to the frameworks in the boards/nucleo_g070rb.json file