### PR TITLE
Add Zephyr support for the Nucleo L552ZE-Q

### DIFF
--- a/boards/nucleo_l552ze_q.json
+++ b/boards/nucleo_l552ze_q.json
@@ -26,7 +26,8 @@
   "frameworks": [
     "arduino",
     "cmsis",
-    "stm32cube"
+    "stm32cube", 
+    "zephyr"
   ],
   "name": "ST Nucleo L552ZE-Q",
   "upload": {


### PR DESCRIPTION
This PR adds Zephyr support for the Nucleo L552ZE-Q. This board is [supported by Zephyr](https://docs.zephyrproject.org/latest/boards/st/nucleo_l552ze_q/doc/nucleol552ze_q.html) but it was not in `boards/nucleo_l552ze_q.json`. I have run some basic code and everything seems to work as expected. 