### PR TITLE
Update nucleo_u575zi_q.json

### DIFF
--- a/boards/nucleo_u575zi_q.json
+++ b/boards/nucleo_u575zi_q.json
@@ -30,7 +30,7 @@
   ],
   "name": "ST Nucleo U575ZI-Q",
   "upload": {
-    "maximum_ram_size": 804864,
+    "maximum_ram_size": 786432,
     "maximum_size": 2097152,
     "protocol": "stlink",
     "protocols": [


### PR DESCRIPTION
Correct Maximum RAM size. See OEM site [here](https://www.st.com/en/microcontrollers-microprocessors/stm32u575zi.html) and related documentation PR [here](https://github.com/platformio/platformio-docs/pull/394)