### PR TITLE
Add board LilyGo T3-STM32

### DIFF
--- a/boards/lilygo_t3_stm32_v1.json
+++ b/boards/lilygo_t3_stm32_v1.json
@@ -1,0 +1,38 @@
+{
+  "build": {
+    "arduino": {
+      "variant_h": "variant_generic.h"
+    },
+    "core": "stm32",
+    "cpu": "cortex-m4",
+    "extra_flags": "-DSTM32WL -DSTM32WLxx -DSTM32WLE5xx",
+    "f_cpu": "48000000L",
+    "framework_extra_flags": {
+      "arduino": "-DUSE_CM4_STARTUP_FILE -DARDUINO_GENERIC_WLE5CCUX"
+    },
+    "mcu": "stm32wle5ccu7",
+    "product_line": "STM32WLE5xx",
+    "variant": "STM32WLxx/WL54CCU_WL55CCU_WLE4C(8-B-C)U_WLE5C(8-B-C)U"
+  },
+  "debug": {
+    "jlink_device": "STM32WLE5CC",
+    "openocd_target": "stm32wlx",
+    "svd_path": "STM32WLE5_CM4.svd"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "LilyGo T3-STM32",
+  "upload": {
+    "maximum_ram_size": 65536,
+    "maximum_size": 262144,
+    "protocol": "serial",
+    "protocols": [
+      "serial",
+      "stlink",
+      "jlink"
+    ]
+  },
+  "url": "https://github.com/Xinyuan-LilyGO/T3-STM32",
+  "vendor": "LilyGo"
+}


### PR DESCRIPTION
- Vendor: LilyGo
- Product page: https://lilygo.cc/products/t3-stm32
- More information (schematics, sample code, etc.): https://github.com/Xinyuan-LilyGO/T3-STM32

Serial upload will not work until PlatformIO stm32flash is updated to include this upstream commit: https://sourceforge.net/p/stm32flash/code/ci/5530160c67df46c0fff9dcdeb46585b1c8512140/

As a workaround, flash the built .hex file using STM32CubeProgrammer (or use `upload_protocol = stlink`).