### PR TITLE
Control J-Link programmer-supplied power during upload

### DIFF
--- a/builder/main.py
+++ b/builder/main.py
@@ -187,7 +187,7 @@ elif upload_protocol.startswith("jlink"):
             "loadbin \"%s\", %s" % (source, board.get(
                 "upload.offset_address", "0x08000000")),
             "r",
-            "q"
+            "exit",
         ]
 
         upload_options = {}
@@ -209,7 +209,9 @@ elif upload_protocol.startswith("jlink"):
             post_pwr_cmds = [
                 f"Sleep {depower_target_post}",
                 "Power off",
+                "exit",
             ]
+            commands.remove("exit")
             commands = commands + post_pwr_cmds
         except:
             pass


### PR DESCRIPTION
Some(/all?) J-link programmers can optionally power the target device: https://kb.segger.com/J-Link_Commander#Power

This change allows for control of that power source during the upload step.

After this change, if I put
```
board_upload.power_target_pre = 3000
board_upload.depower_target_post = 1000
```
info my platformio.ini file, the target will be powered up 3 seconds before the normal upload/flash commands and powered down 1 second after.