### PR TITLE
add support for stm32cubewl

### DIFF
--- a/boards/genericSTM32WLE5C8.json
+++ b/boards/genericSTM32WLE5C8.json
@@ -1,0 +1,44 @@
+{
+  "build": {
+    "core": "stm32",
+    "cpu": "cortex-m4",
+    "extra_flags": "-DSTM32WL -DSTM32WLxx -DSTM32WLE5xx",
+    "f_cpu": "48000000L",
+    "framework_extra_flags": {
+      "arduino": "-DUSE_CM4_STARTUP_FILE"
+    },
+    "mcu": "stm32wle5c8",
+    "product_line": "STM32WLE5xx",
+    "variant": "STM32WLxx"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32WLE5C8",
+    "onboard_tools": [
+      "stlink"
+    ],
+    "openocd_target": "stm32wlx",
+    "svd_path": "STM32WL5E_CM4.svd"
+  },
+  "frameworks": [
+    "arduino",
+    "zephyr",
+    "stm32cube"
+  ],
+  "name": "STM32WLE5C8 (48pins, 20k RAM, 64k Flash)",
+  "upload": {
+    "maximum_ram_size": 20480,
+    "maximum_size": 65536,
+    "protocol": "stlink",
+    "protocols": [
+      "jlink",
+      "cmsis-dap",
+      "stlink",
+      "mbed"
+    ]
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32wl5x-ex.html",
+  "vendor": "ST"
+}

--- a/boards/genericSTM32WLE5CB.json
+++ b/boards/genericSTM32WLE5CB.json
@@ -1,0 +1,44 @@
+{
+  "build": {
+    "core": "stm32",
+    "cpu": "cortex-m4",
+    "extra_flags": "-DSTM32WL -DSTM32WLxx -DSTM32WLE5xx",
+    "f_cpu": "48000000L",
+    "framework_extra_flags": {
+      "arduino": "-DUSE_CM4_STARTUP_FILE"
+    },
+    "mcu": "stm32wle5cb",
+    "product_line": "STM32WLE5xx",
+    "variant": "STM32WLxx"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32WLE5CB",
+    "onboard_tools": [
+      "stlink"
+    ],
+    "openocd_target": "stm32wlx",
+    "svd_path": "STM32WL5E_CM4.svd"
+  },
+  "frameworks": [
+    "arduino",
+    "zephyr",
+    "stm32cube"
+  ],
+  "name": "STM32WLE5CB (48pins, 48k RAM, 128k Flash)",
+  "upload": {
+    "maximum_ram_size": 49152,
+    "maximum_size": 131072,
+    "protocol": "stlink",
+    "protocols": [
+      "jlink",
+      "cmsis-dap",
+      "stlink",
+      "mbed"
+    ]
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32wl5x-ex.html",
+  "vendor": "ST"
+}

--- a/boards/genericSTM32WLE5CC.json
+++ b/boards/genericSTM32WLE5CC.json
@@ -1,0 +1,44 @@
+{
+  "build": {
+    "core": "stm32",
+    "cpu": "cortex-m4",
+    "extra_flags": "-DSTM32WL -DSTM32WLxx -DSTM32WLE5xx",
+    "f_cpu": "48000000L",
+    "framework_extra_flags": {
+      "arduino": "-DUSE_CM4_STARTUP_FILE"
+    },
+    "mcu": "stm32wle5cc",
+    "product_line": "STM32WLE5xx",
+    "variant": "STM32WLxx"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32WLE5CC",
+    "onboard_tools": [
+      "stlink"
+    ],
+    "openocd_target": "stm32wlx",
+    "svd_path": "STM32WL5E_CM4.svd"
+  },
+  "frameworks": [
+    "arduino",
+    "zephyr",
+    "stm32cube"
+  ],
+  "name": "STM32WLE5CC (48pins, 64k RAM, 256k Flash)",
+  "upload": {
+    "maximum_ram_size": 65536,
+    "maximum_size": 262144,
+    "protocol": "stlink",
+    "protocols": [
+      "jlink",
+      "cmsis-dap",
+      "stlink",
+      "mbed"
+    ]
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32wl5x-ex.html",
+  "vendor": "ST"
+}

--- a/boards/genericSTM32WLE5J8.json
+++ b/boards/genericSTM32WLE5J8.json
@@ -1,0 +1,44 @@
+{
+  "build": {
+    "core": "stm32",
+    "cpu": "cortex-m4",
+    "extra_flags": "-DSTM32WL -DSTM32WLxx -DSTM32WLE5xx",
+    "f_cpu": "48000000L",
+    "framework_extra_flags": {
+      "arduino": "-DUSE_CM4_STARTUP_FILE"
+    },
+    "mcu": "stm32wle5j8",
+    "product_line": "STM32WLE5xx",
+    "variant": "STM32WLxx"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32WLE5J8",
+    "onboard_tools": [
+      "stlink"
+    ],
+    "openocd_target": "stm32wlx",
+    "svd_path": "STM32WL5E_CM4.svd"
+  },
+  "frameworks": [
+    "arduino",
+    "zephyr",
+    "stm32cube"
+  ],
+  "name": "STM32WLE5J8 (73pins, 20k RAM, 64k Flash)",
+  "upload": {
+    "maximum_ram_size": 20480,
+    "maximum_size": 65536,
+    "protocol": "stlink",
+    "protocols": [
+      "jlink",
+      "cmsis-dap",
+      "stlink",
+      "mbed"
+    ]
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32wl5x-ex.html",
+  "vendor": "ST"
+}

--- a/boards/genericSTM32WLE5JB.json
+++ b/boards/genericSTM32WLE5JB.json
@@ -1,0 +1,44 @@
+{
+  "build": {
+    "core": "stm32",
+    "cpu": "cortex-m4",
+    "extra_flags": "-DSTM32WL -DSTM32WLxx -DSTM32WLE5xx",
+    "f_cpu": "48000000L",
+    "framework_extra_flags": {
+      "arduino": "-DUSE_CM4_STARTUP_FILE"
+    },
+    "mcu": "stm32wle5jb",
+    "product_line": "STM32WLE5xx",
+    "variant": "STM32WLxx"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32WLE5JB",
+    "onboard_tools": [
+      "stlink"
+    ],
+    "openocd_target": "stm32wlx",
+    "svd_path": "STM32WL5E_CM4.svd"
+  },
+  "frameworks": [
+    "arduino",
+    "zephyr",
+    "stm32cube"
+  ],
+  "name": "STM32WLE5JB (73pins, 48k RAM, 128k Flash)",
+  "upload": {
+    "maximum_ram_size": 49152,
+    "maximum_size": 131072,
+    "protocol": "stlink",
+    "protocols": [
+      "jlink",
+      "cmsis-dap",
+      "stlink",
+      "mbed"
+    ]
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32wl5x-ex.html",
+  "vendor": "ST"
+}

--- a/boards/genericSTM32WLE5JC.json
+++ b/boards/genericSTM32WLE5JC.json
@@ -1,0 +1,44 @@
+{
+  "build": {
+    "core": "stm32",
+    "cpu": "cortex-m4",
+    "extra_flags": "-DSTM32WL -DSTM32WLxx -DSTM32WLE5xx",
+    "f_cpu": "48000000L",
+    "framework_extra_flags": {
+      "arduino": "-DUSE_CM4_STARTUP_FILE"
+    },
+    "mcu": "stm32wle5jc",
+    "product_line": "STM32WLE5xx",
+    "variant": "STM32WLxx"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32WLE5JC",
+    "onboard_tools": [
+      "stlink"
+    ],
+    "openocd_target": "stm32wlx",
+    "svd_path": "STM32WL5E_CM4.svd"
+  },
+  "frameworks": [
+    "arduino",
+    "zephyr",
+    "stm32cube"
+  ],
+  "name": "STM32WLE5JC (73pins, 64k RAM, 256k Flash)",
+  "upload": {
+    "maximum_ram_size": 65536,
+    "maximum_size": 262144,
+    "protocol": "stlink",
+    "protocols": [
+      "jlink",
+      "cmsis-dap",
+      "stlink",
+      "mbed"
+    ]
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32wl5x-ex.html",
+  "vendor": "ST"
+}

--- a/boards/nucleo_wl55jc.json
+++ b/boards/nucleo_wl55jc.json
@@ -24,7 +24,8 @@
   },
   "frameworks": [
     "arduino",
-    "zephyr"
+    "zephyr",
+    "stm32cube"
   ],
   "name": "ST Nucleo WL55JC",
   "upload": {

--- a/platform.json
+++ b/platform.json
@@ -300,6 +300,12 @@
       "owner": "platformio",
       "version": "~1.5.1"
     },
+    "framework-stm32cubewl": {
+      "type": "framework",
+      "optional": true,
+      "owner": "platformio",
+      "version": "~1.4.0"
+    },
     "framework-zephyr": {
       "type": "framework",
       "optional": true,


### PR DESCRIPTION
add support for stm32cubewl

However, a functioning stm32cubewl must be present in the registry. I'm not sure how to achieve this.

Closes #691