### PR TITLE
feat: Add generic STM32WLE5 boards

### DIFF
--- a/boards/genericSTM32WLE5CC.json
+++ b/boards/genericSTM32WLE5CC.json
@@ -1,0 +1,40 @@
+{
+  "build": {
+    "arduino": {
+      "variant_h": "variant_generic.h"
+    },
+    "core": "stm32",
+    "cpu": "cortex-m4",
+    "extra_flags": "-DSTM32WL -DSTM32WLxx -DSTM32WLE5xx",
+    "f_cpu": "48000000L",
+    "framework_extra_flags": {
+      "arduino": "-DUSE_CM4_STARTUP_FILE -DARDUINO_GENERIC_WLE5CCUX"
+    },
+    "mcu": "stm32wle5ccu",
+    "product_line": "STM32WLE5xx",
+    "variant": "STM32WLxx/WL54CCU_WL55CCU_WLE4C(8-B-C)U_WLE5C(8-B-C)U"
+  },
+  "debug": {
+    "jlink_device": "STM32WLE5CC",
+    "openocd_target": "stm32wlx",
+    "svd_path": "STM32WLE5_CM4.svd"
+  },
+  "frameworks": [
+    "arduino",
+    "cmsis",
+    "stm32cube"
+  ],
+  "name": "STM32WLE5CC (64k RAM. 256k Flash)",
+  "upload": {
+    "maximum_ram_size": 65536,
+    "maximum_size": 262144,
+    "protocol": "serial",
+    "protocols": [
+      "jlink",
+      "serial",
+      "stlink"
+    ]
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32wle5cc.html",
+  "vendor": "Generic"
+}

--- a/boards/genericSTM32WLE5JC.json
+++ b/boards/genericSTM32WLE5JC.json
@@ -1,0 +1,40 @@
+{
+  "build": {
+    "arduino": {
+      "variant_h": "variant_generic.h"
+    },
+    "core": "stm32",
+    "cpu": "cortex-m4",
+    "extra_flags": "-DSTM32WL -DSTM32WLxx -DSTM32WLE5xx",
+    "f_cpu": "48000000L",
+    "framework_extra_flags": {
+      "arduino": "-DUSE_CM4_STARTUP_FILE -DARDUINO_GENERIC_WLE5JCIX"
+    },
+    "mcu": "stm32wle5jci",
+    "product_line": "STM32WLE5xx",
+    "variant": "STM32WLxx/WL54JCI_WL55JCI_WLE4J(8-B-C)I_WLE5J(8-B-C)I"
+  },
+  "debug": {
+    "jlink_device": "STM32WLE5JC",
+    "openocd_target": "stm32wlx",
+    "svd_path": "STM32WLE5_CM4.svd"
+  },
+  "frameworks": [
+    "arduino",
+    "cmsis",
+    "stm32cube"
+  ],
+  "name": "STM32WLE5JC (64k RAM. 256k Flash)",
+  "upload": {
+    "maximum_ram_size": 65536,
+    "maximum_size": 262144,
+    "protocol": "serial",
+    "protocols": [
+      "jlink",
+      "serial",
+      "stlink"
+    ]
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32wle5jc.html",
+  "vendor": "Generic"
+}


### PR DESCRIPTION
Add boards:
- genericSTM32WLE5CC
- genericSTM32WLE5JC

As far as I can tell, this may deprecate the following boards:
- lilygo_t3_stm32_v1
- lora_e5_dev_board
- lora_e5_mini
- ebyte_e77_dev

It may be worth cleaning up those boards at some point as there don’t seem to be any actual board-specific configs other than metadata.