### PR TITLE
Add STM32U073Cx & STM32U083Cx boards

### DIFF
--- a/boards/genericSTM32U073C8T.json
+++ b/boards/genericSTM32U073C8T.json
@@ -1,0 +1,39 @@
+{
+  "build": {
+    "core": "stm32",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DSTM32U0 -DSTM32U073xx -DSTM32U073x8 -DARDUINO_GENERIC_U073C8TX",
+    "f_cpu": "56000000L",
+    "mcu": "stm32u073c8t6",
+    "product_line": "STM32U073xx",
+    "variant": "STM32U0xx/U073C(8-B-C)(T-U)_U083CC(T-U)"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32U073C8",
+    "openocd_target": "stm32u0x",
+    "svd_path": "STM32U073.svd"
+  },
+  "frameworks": [
+    "arduino",
+    "cmsis",
+    "stm32cube"
+  ],
+  "name": "STM32U073C8T (40k RAM. 64k Flash)",
+  "upload": {
+    "maximum_ram_size": 40960,
+    "maximum_size": 65536,
+    "protocol": "stlink",
+    "protocols": [
+      "blackmagic",
+      "dfu",
+      "jlink",
+      "serial",
+      "stlink"
+    ]
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32u073c8.html",
+  "vendor": "Generic"
+}

--- a/boards/genericSTM32U073C8U.json
+++ b/boards/genericSTM32U073C8U.json
@@ -1,0 +1,39 @@
+{
+  "build": {
+    "core": "stm32",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DSTM32U0 -DSTM32U073xx -DSTM32U073x8 -DARDUINO_GENERIC_U073C8UX",
+    "f_cpu": "56000000L",
+    "mcu": "stm32u073c8u6",
+    "product_line": "STM32U073xx",
+    "variant": "STM32U0xx/U073C(8-B-C)(T-U)_U083CC(T-U)"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32U073C8",
+    "openocd_target": "stm32u0x",
+    "svd_path": "STM32U073.svd"
+  },
+  "frameworks": [
+    "arduino",
+    "cmsis",
+    "stm32cube"
+  ],
+  "name": "STM32U073C8U (40k RAM. 64k Flash)",
+  "upload": {
+    "maximum_ram_size": 40960,
+    "maximum_size": 65536,
+    "protocol": "stlink",
+    "protocols": [
+      "blackmagic",
+      "dfu",
+      "jlink",
+      "serial",
+      "stlink"
+    ]
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32u073c8.html",
+  "vendor": "Generic"
+}

--- a/boards/genericSTM32U073CBT.json
+++ b/boards/genericSTM32U073CBT.json
@@ -1,0 +1,39 @@
+{
+  "build": {
+    "core": "stm32",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DSTM32U0 -DSTM32U073xx -DSTM32U073xB -DARDUINO_GENERIC_U073CBTX",
+    "f_cpu": "56000000L",
+    "mcu": "stm32u073cbt6",
+    "product_line": "STM32U073xx",
+    "variant": "STM32U0xx/U073C(8-B-C)(T-U)_U083CC(T-U)"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32U073CB",
+    "openocd_target": "stm32u0x",
+    "svd_path": "STM32U073.svd"
+  },
+  "frameworks": [
+    "arduino",
+    "cmsis",
+    "stm32cube"
+  ],
+  "name": "STM32U073CBT (40k RAM. 128k Flash)",
+  "upload": {
+    "maximum_ram_size": 40960,
+    "maximum_size": 131072,
+    "protocol": "stlink",
+    "protocols": [
+      "blackmagic",
+      "dfu",
+      "jlink",
+      "serial",
+      "stlink"
+    ]
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32u073cb.html",
+  "vendor": "Generic"
+}

--- a/boards/genericSTM32U073CBU.json
+++ b/boards/genericSTM32U073CBU.json
@@ -1,0 +1,39 @@
+{
+  "build": {
+    "core": "stm32",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DSTM32U0 -DSTM32U073xx -DSTM32U073xB -DARDUINO_GENERIC_U073CBUX",
+    "f_cpu": "56000000L",
+    "mcu": "stm32u073cbu6",
+    "product_line": "STM32U073xx",
+    "variant": "STM32U0xx/U073C(8-B-C)(T-U)_U083CC(T-U)"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32U073CB",
+    "openocd_target": "stm32u0x",
+    "svd_path": "STM32U073.svd"
+  },
+  "frameworks": [
+    "arduino",
+    "cmsis",
+    "stm32cube"
+  ],
+  "name": "STM32U073CBU (40k RAM. 128k Flash)",
+  "upload": {
+    "maximum_ram_size": 40960,
+    "maximum_size": 131072,
+    "protocol": "stlink",
+    "protocols": [
+      "blackmagic",
+      "dfu",
+      "jlink",
+      "serial",
+      "stlink"
+    ]
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32u073cb.html",
+  "vendor": "Generic"
+}

--- a/boards/genericSTM32U073CCT.json
+++ b/boards/genericSTM32U073CCT.json
@@ -1,0 +1,39 @@
+{
+  "build": {
+    "core": "stm32",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DSTM32U0 -DSTM32U073xx -DSTM32U073xC -DARDUINO_GENERIC_U073CCTX",
+    "f_cpu": "56000000L",
+    "mcu": "stm32u073cct6",
+    "product_line": "STM32U073xx",
+    "variant": "STM32U0xx/U073C(8-B-C)(T-U)_U083CC(T-U)"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32U073CC",
+    "openocd_target": "stm32u0x",
+    "svd_path": "STM32U073.svd"
+  },
+  "frameworks": [
+    "arduino",
+    "cmsis",
+    "stm32cube"
+  ],
+  "name": "STM32U073CCT (40k RAM. 256k Flash)",
+  "upload": {
+    "maximum_ram_size": 40960,
+    "maximum_size": 262144,
+    "protocol": "stlink",
+    "protocols": [
+      "blackmagic",
+      "dfu",
+      "jlink",
+      "serial",
+      "stlink"
+    ]
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32u073cc.html",
+  "vendor": "Generic"
+}

--- a/boards/genericSTM32U073CCU.json
+++ b/boards/genericSTM32U073CCU.json
@@ -1,0 +1,39 @@
+{
+  "build": {
+    "core": "stm32",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DSTM32U0 -DSTM32U073xx -DSTM32U073xC -DARDUINO_GENERIC_U073CCUX",
+    "f_cpu": "56000000L",
+    "mcu": "stm32u073ccu6",
+    "product_line": "STM32U073xx",
+    "variant": "STM32U0xx/U073C(8-B-C)(T-U)_U083CC(T-U)"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32U073CC",
+    "openocd_target": "stm32u0x",
+    "svd_path": "STM32U073.svd"
+  },
+  "frameworks": [
+    "arduino",
+    "cmsis",
+    "stm32cube"
+  ],
+  "name": "STM32U073CCU (40k RAM. 256k Flash)",
+  "upload": {
+    "maximum_ram_size": 40960,
+    "maximum_size": 262144,
+    "protocol": "stlink",
+    "protocols": [
+      "blackmagic",
+      "dfu",
+      "jlink",
+      "serial",
+      "stlink"
+    ]
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32u073cc.html",
+  "vendor": "Generic"
+}

--- a/boards/genericSTM32U073R8I.json
+++ b/boards/genericSTM32U073R8I.json
@@ -1,0 +1,39 @@
+{
+  "build": {
+    "core": "stm32",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DSTM32U0 -DSTM32U073xx -DSTM32U073x8 -DARDUINO_GENERIC_U073R8IX",
+    "f_cpu": "56000000L",
+    "mcu": "stm32u073r8i6",
+    "product_line": "STM32U073xx",
+    "variant": "STM32U0xx/U073R(8-B-C)(I-T)_U083RC(I-T)"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32U073R8",
+    "openocd_target": "stm32u0x",
+    "svd_path": "STM32U073.svd"
+  },
+  "frameworks": [
+    "arduino",
+    "cmsis",
+    "stm32cube"
+  ],
+  "name": "STM32U073R8I (40k RAM. 64k Flash)",
+  "upload": {
+    "maximum_ram_size": 40960,
+    "maximum_size": 65536,
+    "protocol": "stlink",
+    "protocols": [
+      "blackmagic",
+      "dfu",
+      "jlink",
+      "serial",
+      "stlink"
+    ]
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32u073r8.html",
+  "vendor": "Generic"
+}

--- a/boards/genericSTM32U073R8T.json
+++ b/boards/genericSTM32U073R8T.json
@@ -1,0 +1,39 @@
+{
+  "build": {
+    "core": "stm32",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DSTM32U0 -DSTM32U073xx -DSTM32U073x8 -DARDUINO_GENERIC_U073R8TX",
+    "f_cpu": "56000000L",
+    "mcu": "stm32u073r8t6",
+    "product_line": "STM32U073xx",
+    "variant": "STM32U0xx/U073R(8-B-C)(I-T)_U083RC(I-T)"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32U073R8",
+    "openocd_target": "stm32u0x",
+    "svd_path": "STM32U073.svd"
+  },
+  "frameworks": [
+    "arduino",
+    "cmsis",
+    "stm32cube"
+  ],
+  "name": "STM32U073R8T (40k RAM. 64k Flash)",
+  "upload": {
+    "maximum_ram_size": 40960,
+    "maximum_size": 65536,
+    "protocol": "stlink",
+    "protocols": [
+      "blackmagic",
+      "dfu",
+      "jlink",
+      "serial",
+      "stlink"
+    ]
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32u073r8.html",
+  "vendor": "Generic"
+}

--- a/boards/genericSTM32U073RBI.json
+++ b/boards/genericSTM32U073RBI.json
@@ -1,0 +1,39 @@
+{
+  "build": {
+    "core": "stm32",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DSTM32U0 -DSTM32U073xx -DSTM32U073xB -DARDUINO_GENERIC_U073RBIX",
+    "f_cpu": "56000000L",
+    "mcu": "stm32u073rbi6",
+    "product_line": "STM32U073xx",
+    "variant": "STM32U0xx/U073R(8-B-C)(I-T)_U083RC(I-T)"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32U073RB",
+    "openocd_target": "stm32u0x",
+    "svd_path": "STM32U073.svd"
+  },
+  "frameworks": [
+    "arduino",
+    "cmsis",
+    "stm32cube"
+  ],
+  "name": "STM32U073RBI (40k RAM. 128k Flash)",
+  "upload": {
+    "maximum_ram_size": 40960,
+    "maximum_size": 131072,
+    "protocol": "stlink",
+    "protocols": [
+      "blackmagic",
+      "dfu",
+      "jlink",
+      "serial",
+      "stlink"
+    ]
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32u073rb.html",
+  "vendor": "Generic"
+}

--- a/boards/genericSTM32U073RBT.json
+++ b/boards/genericSTM32U073RBT.json
@@ -1,0 +1,39 @@
+{
+  "build": {
+    "core": "stm32",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DSTM32U0 -DSTM32U073xx -DSTM32U073xB -DARDUINO_GENERIC_U073RBTX",
+    "f_cpu": "56000000L",
+    "mcu": "stm32u073rbt6",
+    "product_line": "STM32U073xx",
+    "variant": "STM32U0xx/U073R(8-B-C)(I-T)_U083RC(I-T)"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32U073RB",
+    "openocd_target": "stm32u0x",
+    "svd_path": "STM32U073.svd"
+  },
+  "frameworks": [
+    "arduino",
+    "cmsis",
+    "stm32cube"
+  ],
+  "name": "STM32U073RBT (40k RAM. 128k Flash)",
+  "upload": {
+    "maximum_ram_size": 40960,
+    "maximum_size": 131072,
+    "protocol": "stlink",
+    "protocols": [
+      "blackmagic",
+      "dfu",
+      "jlink",
+      "serial",
+      "stlink"
+    ]
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32u073rb.html",
+  "vendor": "Generic"
+}

--- a/boards/genericSTM32U073RCI.json
+++ b/boards/genericSTM32U073RCI.json
@@ -1,0 +1,39 @@
+{
+  "build": {
+    "core": "stm32",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DSTM32U0 -DSTM32U073xx -DSTM32U073xC -DARDUINO_GENERIC_U073RCIX",
+    "f_cpu": "56000000L",
+    "mcu": "stm32u073rci6",
+    "product_line": "STM32U073xx",
+    "variant": "STM32U0xx/U073R(8-B-C)(I-T)_U083RC(I-T)"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32U073RC",
+    "openocd_target": "stm32u0x",
+    "svd_path": "STM32U073.svd"
+  },
+  "frameworks": [
+    "arduino",
+    "cmsis",
+    "stm32cube"
+  ],
+  "name": "STM32U073RCI (40k RAM. 256k Flash)",
+  "upload": {
+    "maximum_ram_size": 40960,
+    "maximum_size": 262144,
+    "protocol": "stlink",
+    "protocols": [
+      "blackmagic",
+      "dfu",
+      "jlink",
+      "serial",
+      "stlink"
+    ]
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32u073rc.html",
+  "vendor": "Generic"
+}

--- a/boards/genericSTM32U073RCT.json
+++ b/boards/genericSTM32U073RCT.json
@@ -1,0 +1,39 @@
+{
+  "build": {
+    "core": "stm32",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DSTM32U0 -DSTM32U073xx -DSTM32U073xC -DARDUINO_GENERIC_U073RCTX",
+    "f_cpu": "56000000L",
+    "mcu": "stm32u073rct6",
+    "product_line": "STM32U073xx",
+    "variant": "STM32U0xx/U073R(8-B-C)(I-T)_U083RC(I-T)"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32U073RC",
+    "openocd_target": "stm32u0x",
+    "svd_path": "STM32U073.svd"
+  },
+  "frameworks": [
+    "arduino",
+    "cmsis",
+    "stm32cube"
+  ],
+  "name": "STM32U073RCT (40k RAM. 256k Flash)",
+  "upload": {
+    "maximum_ram_size": 40960,
+    "maximum_size": 262144,
+    "protocol": "stlink",
+    "protocols": [
+      "blackmagic",
+      "dfu",
+      "jlink",
+      "serial",
+      "stlink"
+    ]
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32u073rc.html",
+  "vendor": "Generic"
+}

--- a/boards/genericSTM32U083CCT.json
+++ b/boards/genericSTM32U083CCT.json
@@ -1,0 +1,39 @@
+{
+  "build": {
+    "core": "stm32",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DSTM32U0 -DSTM32U083xx -DSTM32U083xC -DARDUINO_GENERIC_U083CCTX",
+    "f_cpu": "56000000L",
+    "mcu": "stm32u083cct6",
+    "product_line": "STM32U083xx",
+    "variant": "STM32U0xx/U073C(8-B-C)(T-U)_U083CC(T-U)"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32U083CC",
+    "openocd_target": "stm32u0x",
+    "svd_path": "STM32U083.svd"
+  },
+  "frameworks": [
+    "arduino",
+    "cmsis",
+    "stm32cube"
+  ],
+  "name": "STM32U083CCT (40k RAM. 256k Flash)",
+  "upload": {
+    "maximum_ram_size": 40960,
+    "maximum_size": 262144,
+    "protocol": "stlink",
+    "protocols": [
+      "blackmagic",
+      "dfu",
+      "jlink",
+      "serial",
+      "stlink"
+    ]
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32u083cc.html",
+  "vendor": "Generic"
+}

--- a/boards/genericSTM32U083CCU.json
+++ b/boards/genericSTM32U083CCU.json
@@ -1,0 +1,39 @@
+{
+  "build": {
+    "core": "stm32",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DSTM32U0 -DSTM32U083xx -DSTM32U083xC -DARDUINO_GENERIC_U083CCUX",
+    "f_cpu": "56000000L",
+    "mcu": "stm32u083ccu6",
+    "product_line": "STM32U083xx",
+    "variant": "STM32U0xx/U073C(8-B-C)(T-U)_U083CC(T-U)"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32U083CC",
+    "openocd_target": "stm32u0x",
+    "svd_path": "STM32U083.svd"
+  },
+  "frameworks": [
+    "arduino",
+    "cmsis",
+    "stm32cube"
+  ],
+  "name": "STM32U083CCU (40k RAM. 256k Flash)",
+  "upload": {
+    "maximum_ram_size": 40960,
+    "maximum_size": 262144,
+    "protocol": "stlink",
+    "protocols": [
+      "blackmagic",
+      "dfu",
+      "jlink",
+      "serial",
+      "stlink"
+    ]
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32u083cc.html",
+  "vendor": "Generic"
+}

--- a/boards/genericSTM32U083RCI.json
+++ b/boards/genericSTM32U083RCI.json
@@ -1,0 +1,39 @@
+{
+  "build": {
+    "core": "stm32",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DSTM32U0 -DSTM32U083xx -DSTM32U083xC -DARDUINO_GENERIC_U083RCIX",
+    "f_cpu": "56000000L",
+    "mcu": "stm32u083rci6",
+    "product_line": "STM32U083xx",
+    "variant": "STM32U0xx/U073R(8-B-C)(I-T)_U083RC(I-T)"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32U083RC",
+    "openocd_target": "stm32u0x",
+    "svd_path": "STM32U083.svd"
+  },
+  "frameworks": [
+    "arduino",
+    "cmsis",
+    "stm32cube"
+  ],
+  "name": "STM32U083RCI (40k RAM. 256k Flash)",
+  "upload": {
+    "maximum_ram_size": 40960,
+    "maximum_size": 262144,
+    "protocol": "stlink",
+    "protocols": [
+      "blackmagic",
+      "dfu",
+      "jlink",
+      "serial",
+      "stlink"
+    ]
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32u083rc.html",
+  "vendor": "Generic"
+}

--- a/boards/genericSTM32U083RCT.json
+++ b/boards/genericSTM32U083RCT.json
@@ -1,0 +1,39 @@
+{
+  "build": {
+    "core": "stm32",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DSTM32U0 -DSTM32U083xx -DSTM32U083xC -DARDUINO_GENERIC_U083RCTX",
+    "f_cpu": "56000000L",
+    "mcu": "stm32u083rct6",
+    "product_line": "STM32U083xx",
+    "variant": "STM32U0xx/U073R(8-B-C)(I-T)_U083RC(I-T)"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32U083RC",
+    "openocd_target": "stm32u0x",
+    "svd_path": "STM32U083.svd"
+  },
+  "frameworks": [
+    "arduino",
+    "cmsis",
+    "stm32cube"
+  ],
+  "name": "STM32U083RCT (40k RAM. 256k Flash)",
+  "upload": {
+    "maximum_ram_size": 40960,
+    "maximum_size": 262144,
+    "protocol": "stlink",
+    "protocols": [
+      "blackmagic",
+      "dfu",
+      "jlink",
+      "serial",
+      "stlink"
+    ]
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32u083rc.html",
+  "vendor": "Generic"
+}

--- a/boards/nucleo_u083rc.json
+++ b/boards/nucleo_u083rc.json
@@ -1,0 +1,45 @@
+{
+  "build": {
+    "core": "stm32",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DSTM32U0 -DSTM32U083xx -DSTM32U083xC",
+    "f_cpu": "56000000L",
+    "framework_extra_flags": {
+      "arduino": "-D__CORTEX_SC=0"
+    },
+    "mcu": "stm32u083rct6",
+    "product_line": "STM32U083xx",
+    "variant": "STM32U0xx/U073R(8-B-C)(I-T)_U083RC(I-T)"
+  },
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32U083RC",
+    "onboard_tools": [
+      "stlink"
+    ],
+    "openocd_target": "stm32u0x",
+    "svd_path": "STM32U083.svd"
+  },
+  "frameworks": [
+    "arduino",
+    "cmsis",
+    "stm32cube"
+  ],
+  "name": "Nucleo U083RC",
+  "upload": {
+    "maximum_ram_size": 40960,
+    "maximum_size": 262144,
+    "protocol": "stlink",
+    "protocols": [
+      "stlink",
+      "jlink",
+      "cmsis-dap",
+      "blackmagic",
+      "mbed"
+    ]
+  },
+  "url": "https://www.st.com/en/evaluation-tools/nucleo-u083rc.html",
+  "vendor": "ST"
+}

--- a/platform.json
+++ b/platform.json
@@ -322,7 +322,7 @@
       "type": "uploader",
       "optional": true,
       "owner": "platformio",
-      "version": "~3.1200.0"
+      "version": "~3.1200.5"
     },
     "tool-jlink": {
       "type": "uploader",

--- a/platform.py
+++ b/platform.py
@@ -201,8 +201,7 @@ class Ststm32Platform(PlatformBase):
                         "Missed target configuration for %s" % board.id)
                     server_args.extend([
                         "-f", "interface/%s.cfg" % link,
-                        "-c", "transport select %s" % (
-                            "hla_swd" if link == "stlink" else "swd"),
+                        "-c", "transport select swd",
                         "-f", "target/%s.cfg" % debug.get("openocd_target")
                     ])
                     server_args.extend(debug.get("openocd_extra_args", []))

--- a/tests/arduino-blink-different-cores/platformio.ini
+++ b/tests/arduino-blink-different-cores/platformio.ini
@@ -368,3 +368,88 @@ board = malyanm200_f103cb
 platform = ststm32
 framework = arduino
 board = malyanm200_f070cb
+
+[env:genericSTM32U073C8T]
+platform = ststm32
+framework = arduino
+board = genericSTM32U073C8T
+
+[env:genericSTM32U073C8U]
+platform = ststm32
+framework = arduino
+board = genericSTM32U073C8U
+
+[env:genericSTM32U073CBT]
+platform = ststm32
+framework = arduino
+board = genericSTM32U073CBT
+
+[env:genericSTM32U073CBU]
+platform = ststm32
+framework = arduino
+board = genericSTM32U073CBU
+
+[env:genericSTM32U073CCT]
+platform = ststm32
+framework = arduino
+board = genericSTM32U073CCT
+
+[env:genericSTM32U073CCU]
+platform = ststm32
+framework = arduino
+board = genericSTM32U073CCU
+
+[env:genericSTM32U073R8I]
+platform = ststm32
+framework = arduino
+board = genericSTM32U073R8I
+
+[env:genericSTM32U073R8T]
+platform = ststm32
+framework = arduino
+board = genericSTM32U073R8T
+
+[env:genericSTM32U073RBI]
+platform = ststm32
+framework = arduino
+board = genericSTM32U073RBI
+
+[env:genericSTM32U073RBT]
+platform = ststm32
+framework = arduino
+board = genericSTM32U073RBT
+
+[env:genericSTM32U073RCI]
+platform = ststm32
+framework = arduino
+board = genericSTM32U073RCI
+
+[env:genericSTM32U073RCT]
+platform = ststm32
+framework = arduino
+board = genericSTM32U073RCT
+
+[env:genericSTM32U083CCT]
+platform = ststm32
+framework = arduino
+board = genericSTM32U083CCT
+
+[env:genericSTM32U083CCU]
+platform = ststm32
+framework = arduino
+board = genericSTM32U083CCU
+
+[env:genericSTM32U083RCI]
+platform = ststm32
+framework = arduino
+board = genericSTM32U083RCI
+
+[env:genericSTM32U083RCT]
+platform = ststm32
+framework = arduino
+board = genericSTM32U083RCT
+
+[env:nucleo_u083rc]
+platform = ststm32
+framework = arduino
+board = nucleo_u083rc


### PR DESCRIPTION
## Summary

Adds board definitions for the STM32U0 series (Cortex-M0+, 56 MHz, 40 KB RAM) and
the required OpenOCD fix to flash them.

### New boards

**STM32U073** - 12 generic variants (all variants supported by upstream Arduino STM32 core)

| Package | 64K (x8) | 128K (xB) | 256K (xC) |
|---------|----------|-----------|-----------|
| C-T     | genericSTM32U073C8T | genericSTM32U073CBT | genericSTM32U073CCT |
| C-U     | genericSTM32U073C8U | genericSTM32U073CBU | genericSTM32U073CCU |
| R-I     | genericSTM32U073R8I | genericSTM32U073RBI | genericSTM32U073RCI |
| R-T     | genericSTM32U073R8T | genericSTM32U073RBT | genericSTM32U073RCT |

**STM32U083** (all variants supported by upstream Arduino STM32 core, including Nucleo U083RC)

| Board | Notes |
|-------|-------|
| genericSTM32U083CCT | C-package, LQFP48 |
| genericSTM32U083CCU | C-package, QFN48 |
| genericSTM32U083RCI | R-package, BGA64 |
| genericSTM32U083RCT | R-package, LQFP64 |
| nucleo_u083rc | ST eval board, onboard ST-Link |

### OpenOCD version bump and hla_swd deprecation

xpack OpenOCD 0.12.0-5 (2025-02-05) deprecated the HLA layer for ST-Link and
converted all interface scripts from `transport select hla_swd` to `swd`. Using
`hla_swd` with xpack ≥ 0.12.0-5 causes OpenOCD to error out. This PR changes
`platform.py` to always emit `transport select swd` for all adapters, and bumps
`tool-openocd` to `~3.1200.5` — also the first release that ships `stm32u0x.cfg`
(required to target STM32U0).

> **Note:** the PlatformIO registry currently only has `tool-openocd @ 3.1200.0`.
> Users must install xpack OpenOCD ≥ 0.12.0-5 manually until the registry is updated.
> Attached is a script to locally update OpenOCD to 0.12.0-7 on MacOS: 
[install-openocd.sh](https://github.com/user-attachments/files/29320704/install-openocd.sh)

### Blink test

Test sketch in `tests/` updated to include all new boards, this was used to test actual hardware (refer to list below).

## Tested on

- [x] All 17 new environments build successfully (Arduino blink, local platform)
- [x] `genericSTM32U073CBT` flashed and verified on actual hardware
- [x] `nucleo_u083rc` flashed and verified on actual hardware


Closes: #798