### PR TITLE
Add WeAct Studio STM32G431 CoreBoard

### DIFF
--- a/boards/weact_g431cb.json
+++ b/boards/weact_g431cb.json
@@ -1,0 +1,37 @@
+{
+  "build": {
+    "core": "stm32",
+    "cpu": "cortex-m4",
+    "extra_flags": "-DSTM32G4 -DSTM32G4xx -DSTM32G431xx",
+    "f_cpu": "170000000L",
+    "mcu": "stm32g431cbu6",
+    "product_line": "STM32G431xx",
+    "variant": "STM32G4xx/G431C(6-8-B)U_G441CBU"
+  },
+  "connectivity": [
+    "can"
+  ],
+  "debug": {
+    "jlink_device": "STM32G431CB",
+    "openocd_target": "stm32g4x",
+    "svd_path": "STM32G431xx.svd"
+  },
+  "frameworks": [
+    "cmsis",
+    "stm32cube"
+  ],
+  "name": "WeAct Studio STM32G431 CoreBoard",
+  "upload": {
+    "maximum_ram_size": 32768,
+    "maximum_size": 131072,
+    "protocol": "stlink",
+    "protocols": [
+      "stlink",
+      "jlink",
+      "cmsis-dap",
+      "blackmagic"
+    ]
+  },
+  "url": "https://github.com/WeActStudio/WeActStudio.STM32G431CoreBoard",
+  "vendor": "WeAct Studio"
+}


### PR DESCRIPTION
## Board: WeAct Studio STM32G431 CoreBoard

**MCU:** STM32G431CBU6
**Package:** 48-pin UFQFPN
**Flash:** 128 KB
**RAM:** 32 KB SRAM
**Clock:** 170 MHz Cortex-M4

**Hardware repo:** https://github.com/WeActStudio/WeActStudio.STM32G431CoreBoard
**Vendor site:** https://weactstudio.com

### Notes
- Frameworks: \`cmsis\`, \`stm32cube\` (arduino omitted — requires variant dir research)
- \`extra_flags\` normalized: \`-DSTM32G4 -DSTM32G4xx -DSTM32G431xx\` (matches genericSTM32G431CB)
- \`variant\`: \`STM32G4xx/G431C(6-8-B)U_G441CBU\` (matches genericSTM32G431CB)