### PR TITLE
Add Zephyr framework support to Nucleo U575ZI-Q

### DIFF
--- a/boards/nucleo_u575zi_q.json
+++ b/boards/nucleo_u575zi_q.json
@@ -26,7 +26,8 @@
   },
   "frameworks": [
     "arduino",
-    "mbed"
+    "mbed",
+    "zephyr"
   ],
   "name": "ST Nucleo U575ZI-Q",
   "upload": {


### PR DESCRIPTION
Supported by Zephyr, see: https://docs.zephyrproject.org/latest/boards/st/nucleo_u575zi_/doc/index.html

The following `platformio.ini` gives the following output:

```
[env:nucleo_u575zi_q]
platform = ststm32
board = nucleo_u575zi_q
upload_protocol = stlink
framework = zephyr
```

```
Generating linker script .pio/build/nucleo_u575zi_q/zephyr/linker.cmd
Archiving .pio/build/nucleo_u575zi_q/zephyr/drivers/timer/libdrivers__timer.a
Indexing .pio/build/nucleo_u575zi_q/zephyr/drivers/timer/libdrivers__timer.a
Archiving .pio/build/nucleo_u575zi_q/zephyr/drivers/serial/libdrivers__serial.a
Indexing .pio/build/nucleo_u575zi_q/zephyr/drivers/serial/libdrivers__serial.a
Archiving .pio/build/nucleo_u575zi_q/modules/hal_stm32/stm32cube/lib_pio__modules__hal__stm32__stm32cube.a
Indexing .pio/build/nucleo_u575zi_q/modules/hal_stm32/stm32cube/lib_pio__modules__hal__stm32__stm32cube.a
Linking .pio/build/nucleo_u575zi_q/zephyr/firmware-pre0.elf
Memory region         Used Size  Region Size  %age Used
           FLASH:       20736 B         2 MB      0.99%
             RAM:        4368 B       768 KB      0.56%
           SRAM0:          0 GB       768 KB      0.00%
        IDT_LIST:         265 B        32 KB      0.81%
Generating ISR table .pio/build/nucleo_u575zi_q/zephyr/isr_tables.c
Compiling .pio/build/nucleo_u575zi_q/zephyr_final/zephyr/isr_tables.c.o
Linking .pio/build/nucleo_u575zi_q/firmware.elf
Memory region         Used Size  Region Size  %age Used
           FLASH:       20736 B         2 MB      0.99%
             RAM:        4368 B       768 KB      0.56%
           SRAM0:          0 GB       768 KB      0.00%
        IDT_LIST:          0 GB        32 KB      0.00%
Checking size .pio/build/nucleo_u575zi_q/firmware.elf
Advanced Memory Usage is available via "PlatformIO Home > Project Inspect"
RAM:   [          ]   0.6% (used 4491 bytes from 786432 bytes)
Flash: [          ]   0.9% (used 19296 bytes from 2097152 bytes)
Building .pio/build/nucleo_u575zi_q/firmware.bin
===== [SUCCESS] Took 26.06 seconds =====
```