### PR TITLE
Add STM32L051C8 generic board

### DIFF
--- a/boards/genericSTM32L051C8.json
+++ b/boards/genericSTM32L051C8.json
@@ -1,0 +1,47 @@
+{
+  "build": {
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DSTM32L0 -DSTM32L051xx",
+    "f_cpu": "32000000L",
+    "framework_extra_flags": {
+      "arduino": "-D__CORTEX_SC=0"
+    },
+    "mcu": "stm32l051c8t6",
+    "product_line": "STM32L051xx",
+    "variant": "STM32L0xx/L051C(6-8)(T-U)"
+  },
+
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32L051C8",
+    "onboard_tools": [
+      "stlink"
+    ],
+    "openocd_target": "stm32l0",
+    "svd_path": "STM32L051.svd"
+  },
+  "frameworks": [
+    "arduino",
+    "cmsis",
+    "stm32cube",
+    "libopencm3",
+    "zephyr"
+  ],
+  "name": "Generic STM32L051C8",
+  "upload": {
+    "maximum_ram_size": 8192,
+    "maximum_size": 65536,
+    "protocol": "stlink",
+    "protocols": [
+      "jlink",
+      "cmsis-dap",
+      "stlink",
+      "blackmagic",
+      "serial"
+    ]
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32l051c8.html",
+  "vendor": "Generic"
+}


### PR DESCRIPTION
Based on `boards/nucleo_l053r8.json`, tested with arduino framework and serial flashing