### PR TITLE
fix weact_g474ceu6 variant, add arduino/libopencm3/dfu support

### DIFF
--- a/boards/weact_g474ceu6.json
+++ b/boards/weact_g474ceu6.json
@@ -6,7 +6,10 @@
     "f_cpu": "170000000L",
     "mcu": "stm32g474ceu6",
     "product_line": "STM32G474xx",
-    "variant": "STM32G4xx/G473R(B-C)T_G473RETx(Z)_G474R(B-C-E)T_G483RET_G484RET"
+    "variant": "STM32G4xx/G473C(B-C-E)U_G474C(B-C-E)U_G483CEU_G484CEU",
+    "arduino": {
+      "board": "WEACT_G474CE"
+    }
   },
   "connectivity": [
     "can"
@@ -17,7 +20,9 @@
     "svd_path": "STM32G474xx.svd"
   },
   "frameworks": [
+    "arduino",
     "cmsis",
+    "libopencm3",
     "stm32cube"
   ],
   "name": "WeAct Studio STM32G474 CoreBoard",
@@ -27,6 +32,7 @@
     "protocol": "stlink",
     "protocols": [
       "stlink",
+      "dfu",
       "jlink",
       "cmsis-dap",
       "blackmagic"

--- a/boards/weact_g474ceu6.json
+++ b/boards/weact_g474ceu6.json
@@ -1,15 +1,18 @@
 {
   "build": {
+    "arduino": {
+      "variant_h": "variant_WEACT_G474CE.h"
+    },
     "core": "stm32",
     "cpu": "cortex-m4",
     "extra_flags": "-DSTM32G4 -DSTM32G4xx -DSTM32G474xx",
     "f_cpu": "170000000L",
+    "framework_extra_flags": {
+      "arduino": "-DARDUINO_WEACT_G474CE"
+    },
     "mcu": "stm32g474ceu6",
     "product_line": "STM32G474xx",
-    "variant": "STM32G4xx/G473C(B-C-E)U_G474C(B-C-E)U_G483CEU_G484CEU",
-    "arduino": {
-      "board": "WEACT_G474CE"
-    }
+    "variant": "STM32G4xx/G473C(B-C-E)U_G474C(B-C-E)U_G483CEU_G484CEU"
   },
   "connectivity": [
     "can"
@@ -31,11 +34,11 @@
     "maximum_size": 524288,
     "protocol": "stlink",
     "protocols": [
-      "stlink",
+      "blackmagic",
+      "cmsis-dap",
       "dfu",
       "jlink",
-      "cmsis-dap",
-      "blackmagic"
+      "stlink"
     ]
   },
   "url": "https://github.com/WeActStudio/WeActStudio.STM32G474CoreBoard",


### PR DESCRIPTION
weact_g474ceu6.json already encodes the correct package in its name (C = 48-pin, U = UFQFPN48) but "variant" incorrectly points to the R-package (LQFP64) variant directory. This patch just points to the correct variant directory.

With that change arduino and libopencm3 support can be enabled as well.