### PR TITLE
Update JLINK upload command, change 'Reset and Halt' to 'Reset and Run'

### DIFF
--- a/builder/main.py
+++ b/builder/main.py
@@ -186,7 +186,7 @@ elif upload_protocol.startswith("jlink"):
             "h",
             "loadbin \"%s\", %s" % (source, board.get(
                 "upload.offset_address", "0x08000000")),
-            "r",
+            "rx 500",
             "q"
         ]
         with open(script_path, "w") as fp:


### PR DESCRIPTION
`r` cmd normally reset device and **HALT CPU**. Program will stuck after reset. I have to tap the RESET button myself after upload, which is troublesome since I may not have a proper button on my board.

~~I think `rx` cmd (Reset and Execute) is more intuitive and convenient. I heard that `q` imediately after `r` or `rx` could cause problem, so I wrote `rx 500`, let JLINK reset device and delay 500ms before quit.~~

OK, I misled by AI, `rx` is short form of `ResetX` and has nothing to do with 'Reset and Execute'. 

```
J-Link>? ResetX
----------------------
Command long name: ResetX
Command short name: RX
Syntax: ResetX <DelayAfterReset>
Function: Reset CPU with delay after reset.
Requires connection to J-Link: yes
Requires connection to target: yes
----------------------
```

But my board does run smoothly after upload with `rx 500`.


