### PR TITLE
Fix ST-Link OpenOCD transport to use swd for modern OpenOCD

### DIFF
--- a/platform.py
+++ b/platform.py
@@ -201,8 +201,7 @@ class Ststm32Platform(PlatformBase):
                         "Missed target configuration for %s" % board.id)
                     server_args.extend([
                         "-f", "interface/%s.cfg" % link,
-                        "-c", "transport select %s" % (
-                            "hla_swd" if link == "stlink" else "swd"),
+                        "-c", "transport select swd",
                         "-f", "target/%s.cfg" % debug.get("openocd_target")
                     ])
                     server_args.extend(debug.get("openocd_extra_args", []))


### PR DESCRIPTION
Fix ST-Link OpenOCD transport to use swd for modern OpenOCD

'''xPack Open On-Chip Debugger 0.12.0+dev-02228-ge5888bda3-dirty (2025-10-04-22:44)
Licensed under GNU GPL v2
For bug reports, read
        http://openocd.org/doc/doxygen/bugs.html
Debug adapter doesn't support 'hla_swd' transport'''